### PR TITLE
Display spot labels in BDV views.

### DIFF
--- a/src/main/java/net/trackmate/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -2,6 +2,7 @@ package net.trackmate.revised.bdv.overlay;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.FontMetrics;
 import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -102,6 +103,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		drawEllipsoidSliceIntersection = settings.getDrawEllipsoidSliceIntersection();
 		drawPoints = settings.getDrawSpotCenters();
 		drawPointsForEllipses = settings.getDrawSpotCentersForEllipses();
+		drawSpotLabels = settings.getDrawSpotLabels();
 		focusLimit = settings.getFocusLimit();
 		isFocusLimitViewRelative = settings.getFocusLimitViewRelative();
 		ellipsoidFadeDepth = settings.getEllipsoidFadeDepth();
@@ -161,22 +163,27 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	private boolean drawPointsForEllipses;
 
 	/**
+	 * Whether to draw spot labels next to ellipses.
+	 */
+	private boolean drawSpotLabels;
+
+	/**
 	 * Maximum distance from view plane up to which to draw spots.
 	 *
 	 * <p>
-	 * Depending on {@link #isFocusLimitViewRelative}, the distance is
-	 * either in the current view coordinate system or in the global coordinate
-	 * system. If {@code isFocusLimitViewRelative() == true} then the
-	 * distance is in current view coordinates. For example, a value of 100
-	 * means that spots will be visible up to 100 pixel widths from the view
-	 * plane. Thus, the effective focus range depends on the current zoom level.
-	 * If {@code isFocusLimitViewRelative() == false} then the distance
-	 * is in global coordinates. A value of 100 means that spots will be visible
-	 * up to 100 units (of the global coordinate system) from the view plane.
+	 * Depending on {@link #isFocusLimitViewRelative}, the distance is either in
+	 * the current view coordinate system or in the global coordinate system. If
+	 * {@code isFocusLimitViewRelative() == true} then the distance is in
+	 * current view coordinates. For example, a value of 100 means that spots
+	 * will be visible up to 100 pixel widths from the view plane. Thus, the
+	 * effective focus range depends on the current zoom level. If
+	 * {@code isFocusLimitViewRelative() == false} then the distance is in
+	 * global coordinates. A value of 100 means that spots will be visible up to
+	 * 100 units (of the global coordinate system) from the view plane.
 	 *
 	 * <p>
-	 * Ellipsoids are drawn increasingly translucent the closer they are
-	 * to {@link #focusLimit}. See {@link #ellipsoidFadeDepth}.
+	 * Ellipsoids are drawn increasingly translucent the closer they are to
+	 * {@link #focusLimit}. See {@link #ellipsoidFadeDepth}.
 	 */
 	private double focusLimit;
 
@@ -453,6 +460,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		final BasicStroke focusedVertexStroke = new BasicStroke( 2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1f, new float[] { 8f, 3f }, 0 );
 		final BasicStroke defaultEdgeStroke = new BasicStroke();
 		final BasicStroke highlightedEdgeStroke = new BasicStroke( 3f );
+		final FontMetrics fontMetrics = graphics.getFontMetrics();
+		final int extraFontHeight = fontMetrics.getAscent() / 2;
+		final int extraFontWidth = fontMetrics.charWidth( ' ' ) / 2;
 
 		final AffineTransform3D transform = getRenderTransformCopy();
 		final int currentTimepoint = renderTimepoint;
@@ -581,6 +591,20 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 							graphics.draw( ellipse );
 							if ( isHighlighted || isFocused )
 								graphics.setStroke( defaultVertexStroke );
+
+							if ( !drawEllipsoidSliceProjection && drawSpotLabels )
+							{
+								graphics.rotate( -theta );
+								final double a = ellipse.getWidth();
+								final double b = ellipse.getHeight();
+								final double cos = Math.cos( theta );
+								final double sin = Math.sin( theta );
+								final double l = Math.sqrt( a * a * cos * cos + b * b * sin * sin );
+								final float xl = ( float ) l / 2 + extraFontWidth;
+								final float yl = extraFontHeight;
+								graphics.drawString( vertex.getLabel(), xl, yl );
+							}
+
 							graphics.setTransform( torig );
 						}
 					}
@@ -603,6 +627,20 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 							graphics.draw( ellipse );
 							if ( isHighlighted || isFocused )
 								graphics.setStroke( defaultVertexStroke );
+
+							if ( drawSpotLabels )
+							{
+								graphics.rotate( -theta );
+								final double a = ellipse.getWidth();
+								final double b = ellipse.getHeight();
+								final double cos = Math.cos( theta );
+								final double sin = Math.sin( theta );
+								final double l = Math.sqrt( a * a * cos * cos + b * b * sin * sin );
+								final float xl = ( float ) l / 2 + extraFontWidth;
+								final float yl = extraFontHeight;
+								graphics.drawString( vertex.getLabel(), xl, yl );
+							}
+
 							graphics.setTransform( torig );
 						}
 

--- a/src/main/java/net/trackmate/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -594,6 +594,8 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							if ( !drawEllipsoidSliceProjection && drawSpotLabels )
 							{
+								// TODO Don't use ellipse, which is an AWT
+								// object, for calculation.
 								graphics.rotate( -theta );
 								final double a = ellipse.getWidth();
 								final double b = ellipse.getHeight();
@@ -630,6 +632,8 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							if ( drawSpotLabels )
 							{
+								// TODO Don't use ellipse, which is an AWT
+								// object, for calculation.
 								graphics.rotate( -theta );
 								final double a = ellipse.getWidth();
 								final double b = ellipse.getHeight();

--- a/src/main/java/net/trackmate/revised/bdv/overlay/OverlayVertex.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/OverlayVertex.java
@@ -4,10 +4,11 @@ import net.imglib2.RealLocalizable;
 import net.imglib2.RealPositionable;
 import net.trackmate.Ref;
 import net.trackmate.graph.Vertex;
+import net.trackmate.revised.model.HasLabel;
 import net.trackmate.spatial.HasTimepoint;
 
 public interface OverlayVertex< O extends OverlayVertex< O, E >, E extends OverlayEdge< E, ? > >
-		extends Vertex< E >, Ref< O >, RealLocalizable, RealPositionable, HasTimepoint
+		extends Vertex< E >, Ref< O >, RealLocalizable, RealPositionable, HasTimepoint, HasLabel
 {
 	public boolean isSelected();
 

--- a/src/main/java/net/trackmate/revised/bdv/overlay/RenderSettings.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/RenderSettings.java
@@ -19,6 +19,7 @@ public class RenderSettings
 	public static final boolean DEFAULT_DRAW_SLICE_PROJECTION = !DEFAULT_DRAW_SLICE_INTERSECTION;
 	public static final boolean DEFAULT_DRAW_POINTS = !DEFAULT_DRAW_ELLIPSE || (DEFAULT_DRAW_ELLIPSE && DEFAULT_DRAW_SLICE_INTERSECTION);
 	public static final boolean DEFAULT_DRAW_POINTS_FOR_ELLIPSE = false;
+	public static final boolean DEFAULT_DRAW_SPOT_LABELS = false;
 	public static final boolean DEFAULT_IS_FOCUS_LIMIT_RELATIVE = true;
 	public static final double DEFAULT_ELLIPSOID_FADE_DEPTH = 0.2;
 	public static final double DEFAULT_POINT_FADE_DEPTH = 0.2;
@@ -41,6 +42,7 @@ public class RenderSettings
 		drawEllipsoidSliceIntersection = DEFAULT_DRAW_SLICE_INTERSECTION;
 		drawPoints = DEFAULT_DRAW_POINTS;
 		drawPointsForEllipses = DEFAULT_DRAW_POINTS_FOR_ELLIPSE;
+		drawSpotLabels = DEFAULT_DRAW_SPOT_LABELS;
 		focusLimit = DEFAULT_LIMIT_FOCUS_RANGE;
 		isFocusLimitViewRelative = DEFAULT_IS_FOCUS_LIMIT_RELATIVE;
 		ellipsoidFadeDepth = DEFAULT_ELLIPSOID_FADE_DEPTH;
@@ -60,6 +62,7 @@ public class RenderSettings
 		drawEllipsoidSliceIntersection = settings.drawEllipsoidSliceIntersection;
 		drawPoints = settings.drawPoints;
 		drawPointsForEllipses = settings.drawPointsForEllipses;
+		drawSpotLabels = settings.drawSpotLabels;
 		focusLimit = settings.focusLimit;
 		isFocusLimitViewRelative = settings.isFocusLimitViewRelative;
 		ellipsoidFadeDepth = settings.ellipsoidFadeDepth;
@@ -142,22 +145,27 @@ public class RenderSettings
 	private boolean drawPointsForEllipses;
 
 	/**
+	 * Whether to draw spot labels next to ellipses.
+	 */
+	private boolean drawSpotLabels;
+
+	/**
 	 * Maximum distance from view plane up to which to draw spots.
 	 *
 	 * <p>
-	 * Depending on {@link #isFocusLimitViewRelative}, the distance is
-	 * either in the current view coordinate system or in the global coordinate
-	 * system. If {@code isFocusLimitViewRelative() == true} then the
-	 * distance is in current view coordinates. For example, a value of 100
-	 * means that spots will be visible up to 100 pixel widths from the view
-	 * plane. Thus, the effective focus range depends on the current zoom level.
-	 * If {@code isFocusLimitViewRelative() == false} then the distance
-	 * is in global coordinates. A value of 100 means that spots will be visible
-	 * up to 100 units (of the global coordinate system) from the view plane.
+	 * Depending on {@link #isFocusLimitViewRelative}, the distance is either in
+	 * the current view coordinate system or in the global coordinate system. If
+	 * {@code isFocusLimitViewRelative() == true} then the distance is in
+	 * current view coordinates. For example, a value of 100 means that spots
+	 * will be visible up to 100 pixel widths from the view plane. Thus, the
+	 * effective focus range depends on the current zoom level. If
+	 * {@code isFocusLimitViewRelative() == false} then the distance is in
+	 * global coordinates. A value of 100 means that spots will be visible up to
+	 * 100 units (of the global coordinate system) from the view plane.
 	 *
 	 * <p>
-	 * Ellipsoids are drawn increasingly translucent the closer they are
-	 * to {@link #focusLimit}. See {@link #ellipsoidFadeDepth}.
+	 * Ellipsoids are drawn increasingly translucent the closer they are to
+	 * {@link #focusLimit}. See {@link #ellipsoidFadeDepth}.
 	 */
 	private double focusLimit;
 
@@ -438,6 +446,31 @@ public class RenderSettings
 		if ( this.drawPointsForEllipses != drawPointsForEllipses )
 		{
 			this.drawPointsForEllipses = drawPointsForEllipses;
+			notifyListeners();
+		}
+	}
+
+	/**
+	 * Get whether spot labels are drawn next to ellipses.
+	 *
+	 * @return whether spot labels are drawn next to ellipses.
+	 */
+	public boolean getDrawSpotLabels()
+	{
+		return drawSpotLabels;
+	}
+
+	/**
+	 * Set whether spot labels are drawn next to ellipses.
+	 *
+	 * @param drawSpotLabels
+	 *            whether spot labels are drawn next to ellipses.
+	 */
+	public void setDrawSpotLabels( final boolean drawSpotLabels )
+	{
+		if ( this.drawSpotLabels != drawSpotLabels )
+		{
+			this.drawSpotLabels = drawSpotLabels;
 			notifyListeners();
 		}
 	}

--- a/src/main/java/net/trackmate/revised/bdv/overlay/ui/RenderSettingsPanel.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/ui/RenderSettingsPanel.java
@@ -48,6 +48,8 @@ public class RenderSettingsPanel extends JPanel implements UpdateListener
 
 	private final JCheckBox centersForEllipsesBox;
 
+	private final JCheckBox drawSpotLabelsBox;
+
 	private final BoundedValueDouble focusLimit;
 
 	private final SliderPanelDouble focusLimitSlider;
@@ -245,9 +247,37 @@ public class RenderSettingsPanel extends JPanel implements UpdateListener
 		add( new JLabel("draw spot centers for ellipses"), c );
 
 
+		/*
+		 * Spot labels
+		 */
+
+		c.gridy++;
+		drawSpotLabelsBox = new JCheckBox();
+		drawSpotLabelsBox.addActionListener( new ActionListener()
+		{
+			@Override
+			public void actionPerformed( final ActionEvent e )
+			{
+//				renderSettings.setDrawSpotLabels( drawSpotLabelsBox.isSelected() );
+			}
+		} );
+		c.anchor = GridBagConstraints.LINE_END;
+		c.gridx = 0;
+		add( drawSpotLabelsBox, c );
+		c.anchor = GridBagConstraints.LINE_START;
+		c.gridx = 1;
+		add( new JLabel( "draw spot labels" ), c );
+
+		/*
+		 * Vertical space.
+		 */
+
 		c.gridy++;
 		add( Box.createVerticalStrut( 15 ), c );
 
+		/*
+		 * Focus limit.
+		 */
 
 		c.gridy++;
 		focusLimit = new BoundedValueDouble( 0, 2000, 100 )

--- a/src/main/java/net/trackmate/revised/bdv/overlay/ui/RenderSettingsPanel.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/ui/RenderSettingsPanel.java
@@ -258,7 +258,7 @@ public class RenderSettingsPanel extends JPanel implements UpdateListener
 			@Override
 			public void actionPerformed( final ActionEvent e )
 			{
-//				renderSettings.setDrawSpotLabels( drawSpotLabelsBox.isSelected() );
+				renderSettings.setDrawSpotLabels( drawSpotLabelsBox.isSelected() );
 			}
 		} );
 		c.anchor = GridBagConstraints.LINE_END;
@@ -386,6 +386,7 @@ public class RenderSettingsPanel extends JPanel implements UpdateListener
 			projectionBox.setSelected( renderSettings.getDrawEllipsoidSliceProjection() );
 			centersBox.setSelected( renderSettings.getDrawSpotCenters() );
 			centersForEllipsesBox.setSelected( renderSettings.getDrawSpotCentersForEllipses() );
+			drawSpotLabelsBox.setSelected( renderSettings.getDrawSpotLabels() );
 
 			focusLimit.setCurrentValue( renderSettings.getFocusLimit() );
 			focusLimitRelativeBox.setSelected( renderSettings.getFocusLimitViewRelative() );

--- a/src/main/java/net/trackmate/revised/bdv/overlay/wrap/OverlayProperties.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/wrap/OverlayProperties.java
@@ -25,4 +25,8 @@ public interface OverlayProperties< V, E >
 	public V addVertex( final int timepoint, final double[] position, final double radius, V ref );
 
 	public void notifyGraphChanged();
+
+	public String getLabel( V v );
+
+	public void setLabel( V v, String label );
 }

--- a/src/main/java/net/trackmate/revised/bdv/overlay/wrap/OverlayVertexWrapper.java
+++ b/src/main/java/net/trackmate/revised/bdv/overlay/wrap/OverlayVertexWrapper.java
@@ -81,6 +81,18 @@ public class OverlayVertexWrapper< V extends Vertex< E >, E extends Edge< V > >
 	}
 
 	@Override
+	public String getLabel()
+	{
+		return overlayProperties.getLabel( wv );
+	}
+
+	@Override
+	public void setLabel( final String label )
+	{
+		overlayProperties.setLabel( wv, label );
+	}
+
+	@Override
 	public Edges< OverlayEdgeWrapper< V, E > > incomingEdges()
 	{
 		return incomingEdges;

--- a/src/main/java/net/trackmate/revised/model/mamut/ModelOverlayProperties.java
+++ b/src/main/java/net/trackmate/revised/model/mamut/ModelOverlayProperties.java
@@ -70,6 +70,18 @@ public class ModelOverlayProperties implements OverlayProperties< Spot, Link >
 	}
 
 	@Override
+	public String getLabel( final Spot v )
+	{
+		return v.getLabel();
+	}
+
+	@Override
+	public void setLabel( final Spot v, final String label )
+	{
+		v.setLabel( label );
+	}
+
+	@Override
 	public boolean isVertexSelected( final Spot v )
 	{
 		return selection.isSelected( v );


### PR DESCRIPTION
A checkbox in the Render settings window allows for specifying whether we draw labels or not.
They are drawn only when spots are visible as ellipses, on the right-hand side of the ellipse. 
This required augmenting the OverlayVertex interface with HasLabel.