### PR TITLE
Overlay graph renderer minor tweaks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.mastodon</groupId>
 			<artifactId>mastodon-collection</artifactId>
-			<version>1.0.0-beta-3-SNAPSHOT</version>
+			<version>1.0.0-beta-6-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mastodon</groupId>

--- a/src/main/java/org/mastodon/revised/bdv/overlay/EditSpecialBehaviours.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/EditSpecialBehaviours.java
@@ -144,11 +144,15 @@ public class EditSpecialBehaviours< V extends OverlayVertex< V, E >, E extends O
 
 				screenVertexMath.init( vertex, transform );
 
-				final double[] tr = screenVertexMath.getProjectCenter();
-				final double theta = screenVertexMath.getProjectTheta();
-				final Ellipse2D ellipse = screenVertexMath.getProjectEllipse();
+				final double[] ep = screenVertexMath.getProjectEllipse();
+				final double ex = ep[ 0 ];
+				final double ey = ep[ 1 ];
+				final double w = ep[ 2 ];
+				final double h = ep[ 3 ];
+				final double theta = ep[ 4 ];
+				final Ellipse2D ellipse = new Ellipse2D.Double( -w, -h, 2 * w, 2 * h );
 
-				graphics.translate( tr[ 0 ], tr[ 1 ] );
+				graphics.translate( ex, ey );
 				graphics.rotate( theta );
 				graphics.draw( ellipse );
 				graphics.setTransform( torig );

--- a/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -143,7 +143,8 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	public static final double pointRadius = 2.5;
 
 	/**
-	 * Antialiasing {@link RenderingHints}.
+	 * Antialiasing settings. Must be one of {@link RenderingHints} antialias
+	 * field.
 	 */
 	private Object antialiasing;
 
@@ -160,15 +161,16 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	private int timeLimit;
 
 	/**
-	 * Whether to draw links (at all).
-	 * For specific settings, see TODO
+	 * Whether to draw links (at all). For specific settings, see
+	 * {@link #useGradient} and {@link #timeLimit}.
 	 */
 	private boolean drawLinks;
 
-
 	/**
-	 * Whether to draw spots (at all).
-	 * For specific settings, see TODO
+	 * Whether to draw spots (at all). For specific settings, see
+	 * {@link #drawEllipsoidSliceIntersection},
+	 * {@link #drawEllipsoidSliceProjection}, {@link #drawPointsForEllipses},
+	 * {@link #drawPoints} and {@link #drawSpotLabels}.
 	 */
 	private boolean drawSpots;
 
@@ -299,13 +301,23 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	}
 
 	/**
-	 * TODO
+	 * Generates a color suitable to paint an abject that might be away from the
+	 * focus plane, or away in time.
 	 *
-	 * @param sd sliceDistande, between -1 and 1. see {@link #sliceDistance(double, double)}.
-	 * @param td timeDistande, between -1 and 1. see {@link #timeDistance(double, double, double)}.
-	 * @param sdFade between 0 and 1, from which |sd| value color starts to fade (alpha value decreases).
-	 * @param tdFade between 0 and 1, from which |td| value color starts to fade (alpha value decreases).
-	 * @param isSelected whether to use selected or un-selected color scheme.
+	 * @param sd
+	 *            sliceDistande, between -1 and 1. see
+	 *            {@link #sliceDistance(double, double)}.
+	 * @param td
+	 *            timeDistande, between -1 and 1. see
+	 *            {@link #timeDistance(double, double, double)}.
+	 * @param sdFade
+	 *            between 0 and 1, from which |sd| value color starts to fade
+	 *            (alpha value decreases).
+	 * @param tdFade
+	 *            between 0 and 1, from which |td| value color starts to fade
+	 *            (alpha value decreases).
+	 * @param isSelected
+	 *            whether to use selected or un-selected color scheme.
 	 * @return vertex/edge color.
 	 */
 	private static Color getColor( final double sd, final double td, final double sdFade, final double tdFade, final boolean isSelected )
@@ -380,8 +392,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	}
 
 	/**
-	 * TODO
-	 * @return
+	 * Returns a copy of the {@link AffineTransform3D} used in this renderer.
+	 *
+	 * @return a new {@link AffineTransform3D} object.
 	 */
 	private AffineTransform3D getRenderTransformCopy()
 	{
@@ -450,7 +463,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		final double maxDepth = isFocusLimitViewRelative
 				? focusLimit
 				: focusLimit * Affine3DHelpers.extractScale( transform, 0 );
-
 
 		graphics.setRenderingHint( RenderingHints.KEY_ANTIALIASING, antialiasing );
 

--- a/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -585,11 +585,15 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 					{
 						if ( screenVertexMath.intersectsViewPlane() )
 						{
-							final double[] tr = screenVertexMath.getIntersectCenter();
-							final double theta = screenVertexMath.getIntersectTheta();
-							final Ellipse2D ellipse = screenVertexMath.getIntersectEllipse();
+							final double[] ep = screenVertexMath.getIntersectEllipse();
+							final double ex = ep[ 0 ];
+							final double ey = ep[ 1 ];
+							final double w = ep[ 2 ];
+							final double h = ep[ 3 ];
+							final double theta = ep[ 4 ];
+							final Ellipse2D ellipse = new Ellipse2D.Double( -w, -h, 2 * w, 2 * h );
 
-							graphics.translate( tr[ 0 ], tr[ 1 ] );
+							graphics.translate( ex, ey );
 							graphics.rotate( theta );
 							graphics.setColor( getColor( 0, 0, ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							if ( isHighlighted )
@@ -602,11 +606,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							if ( !drawEllipsoidSliceProjection && drawSpotLabels )
 							{
-								// TODO Don't use ellipse, which is an AWT
-								// object, for calculation.
 								graphics.rotate( -theta );
-								final double a = ellipse.getWidth();
-								final double b = ellipse.getHeight();
+								final double a = 2. * w;
+								final double b = 2. * h;
 								final double cos = Math.cos( theta );
 								final double sin = Math.sin( theta );
 								final double l = Math.sqrt( a * a * cos * cos + b * b * sin * sin );
@@ -623,11 +625,15 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 					{
 						if ( drawEllipsoidSliceProjection )
 						{
-							final double[] tr = screenVertexMath.getProjectCenter();
-							final double theta = screenVertexMath.getProjectTheta();
-							final Ellipse2D ellipse = screenVertexMath.getProjectEllipse();
+							final double[] ep = screenVertexMath.getProjectEllipse();
+							final double ex = ep[ 0 ];
+							final double ey = ep[ 1 ];
+							final double w = ep[ 2 ];
+							final double h = ep[ 3 ];
+							final double theta = ep[ 4 ];
+							final Ellipse2D ellipse = new Ellipse2D.Double( -w, -h, 2 * w, 2 * h );
 
-							graphics.translate( tr[ 0 ], tr[ 1 ] );
+							graphics.translate( ex, ey );
 							graphics.rotate( theta );
 							graphics.setColor( getColor( sd, 0, ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							if ( isHighlighted )
@@ -640,11 +646,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							if ( drawSpotLabels )
 							{
-								// TODO Don't use ellipse, which is an AWT
-								// object, for calculation.
 								graphics.rotate( -theta );
-								final double a = ellipse.getWidth();
-								final double b = ellipse.getHeight();
+								final double a = 2. * w;
+								final double b = 2. * h;
 								final double cos = Math.cos( theta );
 								final double sin = Math.sin( theta );
 								final double l = Math.sqrt( a * a * cos * cos + b * b * sin * sin );

--- a/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -477,6 +477,11 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		final double timepointDistanceFade = 0.5;
 
 		final ScreenVertexMath screenVertexMath = new ScreenVertexMath();
+		final boolean drawPointAlways = drawPoints
+				&& ( ( !drawEllipsoidSliceIntersection && !drawEllipsoidSliceProjection )
+						|| drawPointsForEllipses );
+		final boolean drawPointMaybe = drawPoints
+				&& !drawEllipsoidSliceProjection && drawEllipsoidSliceIntersection;
 
 		index.readLock().lock();
 		try
@@ -660,11 +665,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 							graphics.setTransform( torig );
 						}
 
-						// TODO: use simplified drawPointMaybe and drawPointAlways from getVisibleVertices()
-						final boolean drawPoint = drawPoints && ( ( !drawEllipsoidSliceIntersection && !drawEllipsoidSliceProjection )
-								|| drawPointsForEllipses
-								|| ( drawEllipsoidSliceIntersection && !screenVertexMath.intersectsViewPlane() ) );
-						if ( drawPoint )
+						if ( drawPointAlways || ( drawPointMaybe && !screenVertexMath.intersectsViewPlane() ) )
 						{
 							graphics.setColor( getColor( sd, 0, pointFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							double radius = pointRadius;
@@ -697,12 +698,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		final int currentTimepoint = renderTimepoint;
 
 		final ConvexPolytope visiblePolytopeGlobal = getVisiblePolytopeGlobal( transform, currentTimepoint );
-
-		// TODO: unused code: remove or improve algorithm.
-		final double[] lPosClick = new double[] { x, y, 0 };
-		final double[] gPosClick = new double[ 3 ];
-		transform.applyInverse( gPosClick, lPosClick );
-
 		index.readLock().lock();
 		try
 		{
@@ -790,6 +785,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	public V getVertexAt( final int x, final int y, final double tolerance, final V ref )
 	{
 		final AffineTransform3D transform = getRenderTransformCopy();
+		final double maxDepth = isFocusLimitViewRelative
+				? focusLimit
+				: focusLimit * Affine3DHelpers.extractScale( transform, 0 );
 		final int currentTimepoint = renderTimepoint;
 
 		final double[] lPos = new double[] { x, y, 0 };
@@ -803,7 +801,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 		// TODO: cache searches? --> take into account that indexdata might change
 
-		// TODO: This needs to take into account maxDepth in the same way that painting does
 		if ( drawEllipsoidSliceProjection )
 		{
 			final ConvexPolytope cropPolytopeGlobal = getSurroundingPolytopeGlobal( x, y, transform, currentTimepoint );
@@ -816,7 +813,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			for ( final V v : ccp.getInsideValues() )
 			{
 				svm.init( v, transform );
-				if ( svm.projectionContainsView( xy ) )
+				final double z = svm.getViewPos()[ 2 ];
+				final double sd = sliceDistance( z, maxDepth );
+				if ( sd > -1 && sd < 1 && svm.projectionContainsView( xy ) )
 				{
 					found = true;
 					v.localize( vPos );
@@ -830,7 +829,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			}
 		}
 
-		// TODO: This needs to take into account maxDepth in the same way that painting does
 		if ( !found && drawEllipsoidSliceIntersection )
 		{
 			final IncrementalNearestNeighborSearch< V > inns = index.getSpatialIndex( currentTimepoint ).getIncrementalNearestNeighborSearch();
@@ -859,14 +857,19 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			if ( v != null )
 			{
 				svm.init( v, transform );
-				final double[] p = svm.getViewPos();
-				final double dx = p[ 0 ] - x;
-				final double dy = p[ 1 ] - y;
-				final double dr = pointRadius + tolerance;
-				if ( dx * dx + dy * dy <= dr * dr )
+				final double z = svm.getViewPos()[ 2 ];
+				final double sd = sliceDistance( z, maxDepth );
+				if ( sd > -1 && sd < 1 )
 				{
-					found = true;
-					ref.refTo( v );
+					final double[] p = svm.getViewPos();
+					final double dx = p[ 0 ] - x;
+					final double dy = p[ 1 ] - y;
+					final double dr = pointRadius + tolerance;
+					if ( dx * dx + dy * dy <= dr * dr )
+					{
+						found = true;
+						ref.refTo( v );
+					}
 				}
 			}
 		}

--- a/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -143,16 +143,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	public static final double pointRadius = 2.5;
 
 	/**
-	 * Color to paint vertices in, and edges when they are close in time.
-	 */
-	private static final Color FIXED_COLOR_1 = Color.GREEN;
-
-	/**
-	 * Edge color to interpolate to when painted edges are far in time.
-	 */
-	private static final Color FIXED_COLOR_2 = Color.RED;
-
-	/**
 	 * Antialiasing settings. Must be one of {@link RenderingHints} antialias
 	 * field.
 	 */
@@ -328,13 +318,9 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	 *            (alpha value decreases).
 	 * @param isSelected
 	 *            whether to use selected or un-selected color scheme.
-	 * @param color1
-	 *            the first color to interpolate from.
-	 * @param color2
-	 *            the second color to interpolate to.
 	 * @return vertex/edge color.
 	 */
-	private static Color getColor( final double sd, final double td, final double sdFade, final double tdFade, final boolean isSelected , final Color color1, final Color color2)
+	private static Color getColor( final double sd, final double td, final double sdFade, final double tdFade, final boolean isSelected )
 	{
 		/*
 		 * |sf| = {                  0  for  |sd| <= sdFade,
@@ -362,19 +348,11 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 			tf = -Math.max( 0, ( -td - tdFade ) / ( 1 - tdFade ) );
 		}
 
-		final double r1 = color1.getRed() / 255.;
-		final double r2 = color2.getRed() / 255.;
-		final double g1 = color1.getGreen() / 255.;
-		final double g2 = color2.getGreen() / 255.;
-		final double b1 = color1.getBlue() / 255.;
-		final double b2 = color2.getBlue() / 255.;
-
-		final double a = r1 + ( -2 * td ) * ( r2 - r1 );
-		final double b = g1 + ( -2 * td ) * ( g2 - g1 );
-		final double c = b1 + ( -2 * td ) * ( b2 - b1 );
+		final double a = -2 * td;
+		final double b = 1 + 2 * td;
 		final double r = isSelected ? b : a;
 		final double g = isSelected ? a : b;
-		return new Color( truncRGBA( r, g, c, ( 1 + tf ) * ( 1 - Math.abs( sf ) ) ), true );
+		return new Color( truncRGBA( r, g, 0.1, ( 1 + tf ) * ( 1 - Math.abs( sf ) ) ), true );
 	}
 
 	/**
@@ -547,12 +525,10 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 							{
 								if ( ( sd0 > -1 && sd0 < 1 ) || ( sd1 > -1 && sd1 < 1 ) )
 								{
-									final Color color1 = edgeColor1( edge );
-									final Color color2 = edgeColor2( edge );
-									final Color c1 = getColor( sd1, td1, sliceDistanceFade, timepointDistanceFade, selection.isSelected( edge ), color1, color2 );
+									final Color c1 = getColor( sd1, td1, sliceDistanceFade, timepointDistanceFade, selection.isSelected( edge ) );
 									if ( useGradient )
 									{
-										final Color c0 = getColor( sd0, td0, sliceDistanceFade, timepointDistanceFade, selection.isSelected( edge ), color1, color2 );
+										final Color c0 = getColor( sd0, td0, sliceDistanceFade, timepointDistanceFade, selection.isSelected( edge ) );
 										graphics.setPaint( new GradientPaint( x0, y0, c0, x1, y1, c1 ) );
 									}
 									else
@@ -624,8 +600,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							graphics.translate( ex, ey );
 							graphics.rotate( theta );
-							final Color color = vertexColor( vertex );
-							graphics.setColor( getColor( 0., 0., ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ), color, color ) );
+							graphics.setColor( getColor( 0, 0, ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							if ( isHighlighted )
 								graphics.setStroke( highlightedVertexStroke );
 							else if ( isFocused )
@@ -665,8 +640,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 							graphics.translate( ex, ey );
 							graphics.rotate( theta );
-							final Color color = vertexColor( vertex );
-							graphics.setColor( getColor( sd, 0., ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ), color, color ) );
+							graphics.setColor( getColor( sd, 0, ellipsoidFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							if ( isHighlighted )
 								graphics.setStroke( highlightedVertexStroke );
 							else if ( isFocused )
@@ -693,8 +667,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 
 						if ( drawPointAlways || ( drawPointMaybe && !screenVertexMath.intersectsViewPlane() ) )
 						{
-							final Color color = vertexColor( vertex );
-							graphics.setColor( getColor( sd, 0., pointFadeDepth, timepointDistanceFade, selection.isSelected( vertex ), color, color ) );
+							graphics.setColor( getColor( sd, 0, pointFadeDepth, timepointDistanceFade, selection.isSelected( vertex ) ) );
 							double radius = pointRadius;
 							if ( isHighlighted || isFocused )
 								radius *= 2;
@@ -717,52 +690,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 		graph.releaseRef( target );
 		graph.releaseRef( ref1 );
 		graph.releaseRef( ref2 );
-	}
-
-	/**
-	 * Returns the color suitable to paint the specified vertex in.
-	 *
-	 * @param vertex
-	 *            the vertex to paint.
-	 * @return a color.
-	 */
-	protected Color vertexColor( final V vertex )
-	{
-		return FIXED_COLOR_1;
-	}
-
-	/**
-	 * Returns the color suitable to paint the specified edge in, when the edge
-	 * is far in time.
-	 * <p>
-	 * The edge color is interpolated from the color returned by
-	 * {@link #edgeColor1(OverlayEdge)} to the color returned by this method as
-	 * it fades in time.
-	 *
-	 * @param edge
-	 *            the edge to paint.
-	 * @return a color.
-	 */
-	protected Color edgeColor2( final E edge )
-	{
-		return FIXED_COLOR_2;
-	}
-
-	/**
-	 * Returns the color suitable to paint the specified edge in, when the edge
-	 * is close in time.
-	 * <p>
-	 * The edge color is interpolated from the color returned by this method to
-	 * the color returned by {@link #edgeColor2(OverlayEdge)} as it fades in
-	 * time.
-	 *
-	 * @param edge
-	 *            the edge to paint.
-	 * @return a color.
-	 */
-	protected Color edgeColor1( final E edge )
-	{
-		return FIXED_COLOR_1;
 	}
 
 	public E getEdgeAt( final int x, final int y, final double tolerance, final E ref )

--- a/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/OverlayGraphRenderer.java
@@ -16,6 +16,7 @@ import org.mastodon.collection.RefList;
 import org.mastodon.kdtree.ClipConvexPolytope;
 import org.mastodon.kdtree.IncrementalNearestNeighborSearch;
 import org.mastodon.revised.Util;
+import org.mastodon.revised.bdv.overlay.util.BdvRendererUtil;
 import org.mastodon.revised.ui.selection.FocusModel;
 import org.mastodon.revised.ui.selection.HighlightModel;
 import org.mastodon.revised.ui.selection.Selection;
@@ -24,10 +25,8 @@ import org.mastodon.spatial.SpatioTemporalIndex;
 
 import bdv.util.Affine3DHelpers;
 import bdv.viewer.TimePointListener;
-import net.imglib2.RealInterval;
 import net.imglib2.RealPoint;
 import net.imglib2.algorithm.kdtree.ConvexPolytope;
-import net.imglib2.algorithm.kdtree.HyperPlane;
 import net.imglib2.neighborsearch.NearestNeighborSearch;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
@@ -345,67 +344,6 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 	}
 
 	/**
-	 * Gets the {@link ConvexPolytope} described by the specified interval in
-	 * viewer coordinates, transformed to global coordinates.
-	 *
-	 * @param transform
-	 *            the transform to transform viewer coordinates back in global
-	 *            coordinates.
-	 * @param viewerInterval
-	 *            the view interval.
-	 * @return {@code viewerInterval} transformed to global coordinates.
-	 */
-	// TODO: move to Utility class
-	public static ConvexPolytope getPolytopeGlobal(
-			final AffineTransform3D transform,
-			final RealInterval viewerInterval )
-	{
-		return getPolytopeGlobal( transform,
-				viewerInterval.realMin( 0 ), viewerInterval.realMax( 0 ),
-				viewerInterval.realMin( 1 ), viewerInterval.realMax( 1 ),
-				viewerInterval.realMin( 2 ), viewerInterval.realMax( 2 ) );
-	}
-
-	/**
-	 * Gets the {@link ConvexPolytope} described by the specified interval in
-	 * viewer coordinates, transformed to global coordinates.
-	 *
-	 * @param transform
-	 *            the transform to transform viewer coordinates back in global
-	 *            coordinates.
-	 * @param viewerMinX
-	 *            the x min bound of the view interval.
-	 * @param viewerMaxX
-	 *            the x max bound of the view interval.
-	 * @param viewerMinY
-	 *            the y min bound of the view interval.
-	 * @param viewerMaxY
-	 *            the y max bound of the view interval.
-	 * @param viewerMinZ
-	 *            the z min bound of the view interval.
-	 * @param viewerMaxZ
-	 *            the z max bound of the view interval.
-	 * @return the specified viewer interval, transformed to global coordinates.
-	 */
-	// TODO: move to Utility class
-	public static ConvexPolytope getPolytopeGlobal(
-			final AffineTransform3D transform,
-			final double viewerMinX, final double viewerMaxX,
-			final double viewerMinY, final double viewerMaxY,
-			final double viewerMinZ, final double viewerMaxZ )
-	{
-		final ConvexPolytope polytopeViewer = new ConvexPolytope(
-				new HyperPlane(  1,  0,  0, viewerMinX ),
-				new HyperPlane( -1,  0,  0, -viewerMaxX ),
-				new HyperPlane(  0,  1,  0, viewerMinY ),
-				new HyperPlane(  0, -1,  0, -viewerMaxY ),
-				new HyperPlane(  0,  0,  1, viewerMinZ),
-				new HyperPlane(  0,  0, -1, -viewerMaxZ ) );
-		final ConvexPolytope polytopeGlobal = ConvexPolytope.transform( polytopeViewer, transform.inverse() );
-		return polytopeGlobal;
-	}
-
-	/**
 	 * Get the {@link ConvexPolytope} around the specified viewer coordinate
 	 * range that is large enough border to ensure that it contains center of
 	 * every ellipsoid touching the specified coordinate range.
@@ -435,7 +373,7 @@ public class OverlayGraphRenderer< V extends OverlayVertex< V, E >, E extends Ov
 				? focusLimit
 				: focusLimit * globalToViewerScale;
 		final double border = globalToViewerScale * Math.sqrt( graph.getMaxBoundingSphereRadiusSquared( timepoint ) );
-		return getPolytopeGlobal( transform,
+		return BdvRendererUtil.getPolytopeGlobal( transform,
 				xMin - border, xMax + border,
 				yMin - border, yMax + border,
 				-maxDepth - border, maxDepth + border );

--- a/src/main/java/org/mastodon/revised/bdv/overlay/ScreenVertexMath.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/ScreenVertexMath.java
@@ -1,7 +1,5 @@
 package org.mastodon.revised.bdv.overlay;
 
-import java.awt.geom.Ellipse2D;
-
 import org.mastodon.revised.bdv.overlay.util.JamaEigenvalueDecomposition;
 
 import net.imglib2.RealLocalizable;
@@ -60,21 +58,23 @@ public class ScreenVertexMath
 	private final double[][] vP = new double[ 2 ][ 2 ];
 
 	/**
-	 * center of 2D ellipse obtained by projecting ellipsoid to z=0 plane.
+	 * Parameters of the 2D ellipse obtained by projecting the ellipsoid onto
+	 * the z=0 plane. Parameters are stored as follow:
+	 * <ol start="0">
+	 * <li>X center of the ellipse;</li>
+	 * <li>Y center of the ellipse;</li>
+	 * <li>half-width (along X axis) of the ellipse;</li>
+	 * <li>half-height (along Y axis) of the ellipse;</li>
+	 * <li>rotation angle (X axis) of the ellipse in radians.</li>
+	 * </ol>
+	 */
+	private final double[] projectEllipse = new double[ 5 ];
+
+	/**
+	 * Only used in
+	 * {@link #projectionIntersectsViewInterval(double, double, double, double)}.
 	 */
 	private final double[] projectCenter = new double[ 2 ];
-
-	/**
-	 * rotation angle of 2D ellipse obtained by projecting ellipsoid to z=0 plane.
-	 */
-	private double projectTheta;
-
-	/**
-	 * 2D ellipse obtained by projecting ellipsoid to z=0 plane. To draw it,
-	 * need to translate by {@link #projectCenter} and rotate by
-	 * {@link #projectTheta}.
-	 */
-	private Ellipse2D projectEllipse;
 
 	/**
 	 * whether the ellipsoid intersects the z=0 plane.
@@ -82,21 +82,23 @@ public class ScreenVertexMath
 	private boolean intersectsViewPlane;
 
 	/**
-	 * center of 2D ellipse obtained by intersecting ellipsoid with z=0 plane.
+	 * Parameters of the ellipse obtained by intersecting the ellipsoid with z=0
+	 * plane. Parameters are stored as follow:
+	 * <ol start="0">
+	 * <li>X center of the ellipse;</li>
+	 * <li>Y center of the ellipse;</li>
+	 * <li>half-width (along X axis) of the ellipse;</li>
+	 * <li>half-height (along Y axis) of the ellipse;</li>
+	 * <li>rotation angle (X axis) of the ellipse in radians.</li>
+	 * </ol>
+	 */
+	private final double[] intersectEllipse = new double[ 5 ];
+
+	/**
+	 * Only used in
+	 * {@link #intersectionIntersectsViewInterval(double, double, double, double)}.
 	 */
 	private final double[] intersectCenter = new double[ 2 ];
-
-	/**
-	 * rotation angle of 2D ellipse obtained by intersecting ellipsoid with z=0 plane.
-	 */
-	private double intersectTheta;
-
-	/**
-	 * 2D ellipse obtained by intersecting ellipsoid with z=0 plane. To draw
-	 * it, need to translate by {@link #intersectCenter} and rotate by
-	 * {@link #intersectTheta}.
-	 */
-	private Ellipse2D intersectEllipse;
 
 	private boolean projectionComputed;
 
@@ -137,12 +139,14 @@ public class ScreenVertexMath
 	private final double[] diff2 = new double[ 2 ];
 
 	/**
-	 * covariance of 2D ellipse obtained by intersecting ellipsoid with z=0 plane.
+	 * covariance of 2D ellipse obtained by intersecting ellipsoid with z=0
+	 * plane.
 	 */
 	private final double[][] iS = new double[ 2 ][ 2 ];
 
 	/**
-	 * precision of 2D ellipse obtained by intersecting ellipsoid with z=0 plane.
+	 * precision of 2D ellipse obtained by intersecting ellipsoid with z=0
+	 * plane.
 	 */
 	private final double[][] iP = new double[ 2 ][ 2 ];
 
@@ -189,38 +193,22 @@ public class ScreenVertexMath
 	}
 
 	/**
-	 * Get center of 2D ellipse obtained by projecting ellipsoid to z=0 plane.
+	 * Returns the parameters of the 2D ellipse obtained by projecting the
+	 * ellipsoid onto the z=0 plane.
+	 * <p>
+	 * Parameters are stored as follow:
+	 * <ol start="0">
+	 * <li>X center of the ellipse;</li>
+	 * <li>Y center of the ellipse;</li>
+	 * <li>half-width (along X axis) of the ellipse;</li>
+	 * <li>half-height (along Y axis) of the ellipse;</li>
+	 * <li>rotation angle (X axis) of the ellipse in radians.</li>
+	 * </ol>
 	 *
-	 * @return center of 2D ellipse obtained by projecting ellipsoid to z=0
-	 *         plane.
+	 * @return the parameters the 2D ellipse obtained by projecting the
+	 *         ellipsoid onto the z=0 plane.
 	 */
-	public double[] getProjectCenter()
-	{
-		computeProjection();
-		return projectCenter;
-	}
-
-	/**
-	 * Get the rotation angle (in radian) of 2D ellipse obtained by projecting
-	 * ellipsoid to z=0 plane.
-	 *
-	 * @return rotation angle of 2D ellipse obtained by projecting ellipsoid to
-	 *         z=0 plane.
-	 */
-	public double getProjectTheta()
-	{
-		computeProjection();
-		return projectTheta;
-	}
-
-	/**
-	 * Get the 2D ellipse obtained by projecting ellipsoid to z=0 plane. To draw
-	 * it, you need to translate by {@link #getProjectCenter()} and rotate by
-	 * {@link #getProjectTheta()}.
-	 *
-	 * @return 2D ellipse obtained by projecting ellipsoid to z=0 plane.
-	 */
-	public Ellipse2D getProjectEllipse()
+	public double[] getProjectEllipse()
 	{
 		computeProjection();
 		return projectEllipse;
@@ -238,39 +226,22 @@ public class ScreenVertexMath
 	}
 
 	/**
-	 * Get center of 2D ellipse obtained by intersecting ellipsoid with z=0
-	 * plane.
+	 * Returns the parameters of the 2D ellipse obtained by intersecting the
+	 * ellipsoid with the z=0 plane.
+	 * <p>
+	 * Parameters are stored as follow:
+	 * <ol start="0">
+	 * <li>X center of the ellipse;</li>
+	 * <li>Y center of the ellipse;</li>
+	 * <li>half-width (along X axis) of the ellipse;</li>
+	 * <li>half-height (along Y axis) of the ellipse;</li>
+	 * <li>rotation angle (X axis) of the ellipse in radians.</li>
+	 * </ol>
 	 *
-	 * @return center of 2D ellipse obtained by intersecting ellipsoid with z=0
-	 *         plane.
+	 * @return the parameters the 2D ellipse obtained by intersecting the
+	 *         ellipsoid with the z=0 plane.
 	 */
-	public double[] getIntersectCenter()
-	{
-		computeIntersection();
-		return intersectCenter;
-	}
-
-	/**
-	 * Get the rotation angle ( in radian) of 2D ellipse obtained by
-	 * intersecting ellipsoid with z=0 plane.
-	 *
-	 * @return rotation angle of 2D ellipse obtained by intersecting ellipsoid
-	 *         with z=0 plane.
-	 */
-	public double getIntersectTheta()
-	{
-		computeIntersection();
-		return intersectTheta;
-	}
-
-	/**
-	 * Get the 2D ellipse obtained by intersecting ellipsoid with z=0 plane. To
-	 * draw it, you need to translate by {@link #getIntersectCenter()} and
-	 * rotate by {@link #getIntersectTheta()}.
-	 *
-	 * @return 2D ellipse obtained by intersecting ellipsoid with z=0 plane.
-	 */
-	public Ellipse2D getIntersectEllipse()
+	public double[] getIntersectEllipse()
 	{
 		computeIntersection();
 		return intersectEllipse;
@@ -463,8 +434,8 @@ public class ScreenVertexMath
 			return;
 
 		/*
-		 * decompose the upper 2x2 sub-matrix of S, i.e., the spot
-		 * covariance in XY of the viewer coordinate system.
+		 * decompose the upper 2x2 sub-matrix of S, i.e., the spot covariance in
+		 * XY of the viewer coordinate system.
 		 */
 		eig2.decomposeSymmetric( vS );
 		final double[] eigVals2 = eig2.getRealEigenvalues();
@@ -473,10 +444,13 @@ public class ScreenVertexMath
 		final double c = eig2.getV()[ 0 ][ 0 ];
 		final double s = eig2.getV()[ 1 ][ 0 ];
 
-		projectTheta = Math.atan2( s, c );
 		projectCenter[ 0 ] = vPos[ 0 ];
 		projectCenter[ 1 ] = vPos[ 1 ];
-		projectEllipse = new Ellipse2D.Double( -w, -h, 2 * w, 2 * h );
+		projectEllipse[ 0 ] = projectCenter[ 0 ];
+		projectEllipse[ 1 ] = projectCenter[ 1 ];
+		projectEllipse[ 2 ] = w;
+		projectEllipse[ 3 ] = h;
+		projectEllipse[ 4 ] = Math.atan2( s, c );
 
 		projectionComputed = true;
 	}
@@ -538,7 +512,8 @@ public class ScreenVertexMath
 			iS[ 1 ][ 0 ] = iS[ 0 ][ 1 ];
 			iS[ 1 ][ 1 ] = radius2 / b2;
 			/*
-			 * now iS is the 2D covariance ellipsoid of transformed circle with radius
+			 * now iS is the 2D covariance ellipsoid of transformed circle with
+			 * radius
 			 */
 
 			eig2.decomposeSymmetric( iS );
@@ -548,10 +523,13 @@ public class ScreenVertexMath
 			final double ci = eig2.getV()[ 0 ][ 0 ];
 			final double si = eig2.getV()[ 1 ][ 0 ];
 
-			intersectTheta = Math.atan2( si, ci );
 			intersectCenter[ 0 ] = vPos[ 0 ] + xshift;
 			intersectCenter[ 1 ] = vPos[ 1 ] + yshift;
-			intersectEllipse = new Ellipse2D.Double( -w, -h, 2 * w, 2 * h );
+			intersectEllipse[ 0 ] = intersectCenter[ 0 ];
+			intersectEllipse[ 1 ] = intersectCenter[ 1 ];
+			intersectEllipse[ 2 ] = w;
+			intersectEllipse[ 3 ] = h;
+			intersectEllipse[ 4 ] = Math.atan2( si, ci );
 		}
 
 		intersectionComputed = true;

--- a/src/main/java/org/mastodon/revised/bdv/overlay/util/BdvRendererUtil.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/util/BdvRendererUtil.java
@@ -1,0 +1,75 @@
+package org.mastodon.revised.bdv.overlay.util;
+
+import net.imglib2.RealInterval;
+import net.imglib2.algorithm.kdtree.ConvexPolytope;
+import net.imglib2.algorithm.kdtree.HyperPlane;
+import net.imglib2.realtransform.AffineTransform3D;
+
+public class BdvRendererUtil
+{
+
+
+	/**
+	 * Gets the {@link ConvexPolytope} described by the specified interval in
+	 * viewer coordinates, transformed to global coordinates.
+	 *
+	 * @param transform
+	 *            the transform to transform viewer coordinates back in global
+	 *            coordinates.
+	 * @param viewerInterval
+	 *            the view interval.
+	 * @return {@code viewerInterval} transformed to global coordinates.
+	 */
+	public static ConvexPolytope getPolytopeGlobal(
+			final AffineTransform3D transform,
+			final RealInterval viewerInterval )
+	{
+		return getPolytopeGlobal( transform,
+				viewerInterval.realMin( 0 ), viewerInterval.realMax( 0 ),
+				viewerInterval.realMin( 1 ), viewerInterval.realMax( 1 ),
+				viewerInterval.realMin( 2 ), viewerInterval.realMax( 2 ) );
+	}
+
+	/**
+	 * Gets the {@link ConvexPolytope} described by the specified interval in
+	 * viewer coordinates, transformed to global coordinates.
+	 *
+	 * @param transform
+	 *            the transform to transform viewer coordinates back in global
+	 *            coordinates.
+	 * @param viewerMinX
+	 *            the x min bound of the view interval.
+	 * @param viewerMaxX
+	 *            the x max bound of the view interval.
+	 * @param viewerMinY
+	 *            the y min bound of the view interval.
+	 * @param viewerMaxY
+	 *            the y max bound of the view interval.
+	 * @param viewerMinZ
+	 *            the z min bound of the view interval.
+	 * @param viewerMaxZ
+	 *            the z max bound of the view interval.
+	 * @return the specified viewer interval, transformed to global coordinates.
+	 */
+	public static ConvexPolytope getPolytopeGlobal(
+			final AffineTransform3D transform,
+			final double viewerMinX, final double viewerMaxX,
+			final double viewerMinY, final double viewerMaxY,
+			final double viewerMinZ, final double viewerMaxZ )
+	{
+		final ConvexPolytope polytopeViewer = new ConvexPolytope(
+				new HyperPlane(  1,  0,  0, viewerMinX ),
+				new HyperPlane( -1,  0,  0, -viewerMaxX ),
+				new HyperPlane(  0,  1,  0, viewerMinY ),
+				new HyperPlane(  0, -1,  0, -viewerMaxY ),
+				new HyperPlane(  0,  0,  1, viewerMinZ),
+				new HyperPlane(  0,  0, -1, -viewerMaxZ ) );
+		final ConvexPolytope polytopeGlobal = ConvexPolytope.transform( polytopeViewer, transform.inverse() );
+		return polytopeGlobal;
+	}
+
+
+	private BdvRendererUtil()
+	{}
+
+}

--- a/src/main/java/org/mastodon/revised/bdv/overlay/wrap/OverlayVertexWrapper.java
+++ b/src/main/java/org/mastodon/revised/bdv/overlay/wrap/OverlayVertexWrapper.java
@@ -1,7 +1,5 @@
 package org.mastodon.revised.bdv.overlay.wrap;
 
-import java.util.Iterator;
-
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Edges;
 import org.mastodon.graph.Vertex;
@@ -21,11 +19,11 @@ public class OverlayVertexWrapper< V extends Vertex< E >, E extends Edge< V > >
 
 	V wv;
 
-	private final EdgesWrapper incomingEdges;
+	private final OverlayGraphWrapper< V, E >.EdgesWrapper incomingEdges;
 
-	private final EdgesWrapper outgoingEdges;
+	private final OverlayGraphWrapper< V, E >.EdgesWrapper outgoingEdges;
 
-	private final EdgesWrapper edges;
+	private final OverlayGraphWrapper< V, E >.EdgesWrapper edges;
 
 	private final OverlayProperties< V, E > overlayProperties;
 
@@ -33,9 +31,9 @@ public class OverlayVertexWrapper< V extends Vertex< E >, E extends Edge< V > >
 	{
 		this.wrapper = wrapper;
 		ref = wrapper.wrappedGraph.vertexRef();
-		incomingEdges = new EdgesWrapper();
-		outgoingEdges = new EdgesWrapper();
-		edges = new EdgesWrapper();
+		incomingEdges = wrapper.new EdgesWrapper();
+		outgoingEdges = wrapper.new EdgesWrapper();
+		edges = wrapper.new EdgesWrapper();
 		overlayProperties = wrapper.overlayProperties;
 	}
 
@@ -153,59 +151,6 @@ public class OverlayVertexWrapper< V extends Vertex< E >, E extends Edge< V > >
 	static < V extends Vertex< ? > > V wrappedOrNull( final OverlayVertexWrapper< V, ? > wrapper )
 	{
 		return wrapper == null ? null : wrapper.wv;
-	}
-
-	private class EdgesWrapper implements Edges< OverlayEdgeWrapper< V, E > >
-	{
-		private Edges< E > wrappedEdges;
-
-		private OverlayEdgeIteratorWrapper< V, E > iterator = null;
-
-		void wrap( final Edges< E > edges )
-		{
-			wrappedEdges = edges;
-		}
-
-		@Override
-		public Iterator< OverlayEdgeWrapper< V, E > > iterator()
-		{
-			if ( iterator == null )
-				iterator = new OverlayEdgeIteratorWrapper<>( wrapper, wrapper.edgeRef(), wrappedEdges.iterator() );
-			else
-				iterator.wrap( wrappedEdges.iterator() );
-			return iterator;
-		}
-
-		@Override
-		public int size()
-		{
-			return wrappedEdges.size();
-		}
-
-		@Override
-		public boolean isEmpty()
-		{
-			return wrappedEdges.isEmpty();
-		}
-
-		@Override
-		public OverlayEdgeWrapper< V, E > get( final int i )
-		{
-			return get( i, wrapper.edgeRef() );
-		}
-
-		@Override
-		public OverlayEdgeWrapper< V, E > get( final int i, final OverlayEdgeWrapper< V, E > edge )
-		{
-			edge.we = wrappedEdges.get( i, edge.ref );
-			return edge;
-		}
-
-		@Override
-		public Iterator< OverlayEdgeWrapper< V, E > > safe_iterator()
-		{
-			return new OverlayEdgeIteratorWrapper<>( wrapper, wrapper.edgeRef(), wrappedEdges.iterator() );
-		}
 	}
 
 	// === RealLocalizable ===

--- a/src/main/java/org/mastodon/revised/model/mamut/tgmm/TgmmImporter.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/tgmm/TgmmImporter.java
@@ -14,7 +14,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.mastodon.collection.IntRefMap;
-import org.mastodon.collection.RefCollections;
+import org.mastodon.collection.RefMaps;
 import org.mastodon.graph.Graph;
 import org.mastodon.revised.model.AbstractModelImporter;
 import org.mastodon.revised.model.mamut.Link;
@@ -120,8 +120,8 @@ public class TgmmImporter extends AbstractModelImporter< Model >
 		final Spot tmp = graph.vertexRef();
 		final Link edge = graph.edgeRef();
 
-		IntRefMap< Spot > idToSpot = RefCollections.createIntRefMap( graph.vertices(), -1, 2000 );
-		IntRefMap< Spot > previousIdToSpot = RefCollections.createIntRefMap( graph.vertices(), -1, 2000 );
+		IntRefMap< Spot > idToSpot = RefMaps.createIntRefMap( graph.vertices(), -1, 2000 );
+		IntRefMap< Spot > previousIdToSpot = RefMaps.createIntRefMap( graph.vertices(), -1, 2000 );
 
 		for ( final TimePoint timepoint : timepointsToRead.getTimePointsOrdered() )
 		{

--- a/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImporter.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/trackmate/TrackMateImporter.java
@@ -35,7 +35,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.mastodon.collection.IntRefMap;
-import org.mastodon.collection.RefCollections;
+import org.mastodon.collection.RefMaps;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.mamut.Link;
@@ -172,7 +172,7 @@ public class TrackMateImporter
 			final double[] pos = new double[ 3 ];
 
 			// Map spot ID -> Vertex
-			final IntRefMap< Spot > idToSpotIDmap = RefCollections.createIntRefMap( graph.vertices(), -1 );
+			final IntRefMap< Spot > idToSpotIDmap = RefMaps.createIntRefMap( graph.vertices(), -1 );
 
 			/*
 			 * Import spots.

--- a/src/main/java/org/mastodon/revised/trackscheme/display/ui/dummygraph/DummyGraph.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/ui/dummygraph/DummyGraph.java
@@ -171,6 +171,10 @@ public class DummyGraph extends AbstractObjectIdGraph< DummyVertex, DummyEdge > 
 				{
 					selectedEdges.add( edge );
 				}
+
+				@Override
+				public void crossComponent( final DummyVertex from, final DummyVertex to, final DepthFirstSearch< DummyVertex, DummyEdge > search )
+				{}
 			} );
 			dfs.start( ABa );
 		}

--- a/src/main/java/org/mastodon/revised/ui/SelectionActions.java
+++ b/src/main/java/org/mastodon/revised/ui/SelectionActions.java
@@ -4,7 +4,6 @@
 package org.mastodon.revised.ui;
 
 import org.mastodon.collection.RefCollections;
-import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefSet;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.GraphChangeNotifier;
@@ -32,6 +31,18 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 
 	private static final String[] DELETE_SELECTION_KEYS = new String[] { "shift DELETE" };
 
+	private static final String SELECT_WHOLE_TRACK = "select whole track";
+
+	private static final String SELECT_WHOLE_TRACK_KEYS = "shift SPACE";
+
+	private static final String SELECT_TRACK_DOWNWARD = "select track downward";
+
+	private static final String SELECT_TRACK_DOWNWARD_KEYS = "shift PAGE_DOWN";
+
+	private static final String SELECT_TRACK_UPWARD = "select track upward";
+
+	private static final String SELECT_TRACK_UPWARD_KEYS = "shift PAGE_UP";
+
 	public static < V extends Vertex< E >, E extends Edge< V > > void installActionBindings(
 			final InputActionBindings inputActionBindings,
 			final InputTriggerConfig config,
@@ -44,6 +55,9 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 		final SelectionActions< V, E > sa = new SelectionActions<>( config, keyConfigContexts, graph, notify, selection, undo );
 
 		sa.runnableAction( sa.getDeleteSelectionAction(), DELETE_SELECTION, DELETE_SELECTION_KEYS );
+		sa.runnableAction( sa.getSelectWholeTrackAction( true ), SELECT_WHOLE_TRACK, SELECT_WHOLE_TRACK_KEYS );
+		sa.runnableAction( sa.getSelectTrackDownardAction( true ), SELECT_TRACK_DOWNWARD, SELECT_TRACK_DOWNWARD_KEYS );
+		sa.runnableAction( sa.getSelectTrackUpwardAction( true ), SELECT_TRACK_UPWARD, SELECT_TRACK_UPWARD_KEYS );
 
 		sa.install( inputActionBindings, "selection" );
 	}
@@ -75,17 +89,17 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 		deleteSelectionAction = new DeleteSelectionAction();
 	}
 
-	public Runnable getSelectWholeTrackAction(final boolean clear)
+	private Runnable getSelectWholeTrackAction( final boolean clear )
 	{
 		return new TrackSelectionAction( SearchDirection.UNDIRECTED, clear );
 	}
 
-	public Runnable getSelectTrackDownardAction( final boolean clear )
+	private Runnable getSelectTrackDownardAction( final boolean clear )
 	{
 		return new TrackSelectionAction( SearchDirection.DIRECTED, clear );
 	}
 
-	public Runnable getSelectTrackUpwardAction( final boolean clear )
+	private Runnable getSelectTrackUpwardAction( final boolean clear )
 	{
 		return new TrackSelectionAction( SearchDirection.REVERSED, clear );
 	}
@@ -133,13 +147,22 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 		public void run()
 		{
 			selection.pauseListeners();
-			final RefSet< V > vertices = selection.getSelectedVertices();
+			final RefSet< V > vertices = RefCollections.createRefSet( graph.vertices() );
+			vertices.addAll( selection.getSelectedVertices() );
+			final V ref = graph.vertexRef();
+			for ( final E e : selection.getSelectedEdges() )
+			{
+				vertices.add( e.getSource( ref ) );
+				vertices.add( e.getTarget( ref ) );
+			}
+			graph.releaseRef( ref );
+
 			if ( clear )
 				selection.clearSelection();
 
 			// Prepare the iterator.
-			final RefList< V > vList = RefCollections.createRefList( graph.vertices() );
-			final RefList< E > eList = RefCollections.createRefList( graph.edges() );
+			final RefSet< V > vSet = RefCollections.createRefSet( graph.vertices() );
+			final RefSet< E > eSet = RefCollections.createRefSet( graph.edges() );
 			final DepthFirstSearch< V, E > search = new DepthFirstSearch<>( graph, directivity );
 			search.setTraversalListener( new SearchListener< V, E, DepthFirstSearch< V, E > >()
 			{
@@ -151,28 +174,32 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 				@Override
 				public void processVertexEarly( final V vertex, final DepthFirstSearch< V, E > search )
 				{
-					vList.add( vertex );
+					vSet.add( vertex );
 				}
 
 				@Override
 				public void processEdge( final E edge, final V from, final V to, final DepthFirstSearch< V, E > search )
 				{
-					eList.add( edge );
+					eSet.add( edge );
 				}
+
+				@Override
+				public void crossComponent( final V from, final V to, final DepthFirstSearch< V, E > search )
+				{}
 			} );
 
 			// Iterate from all vertices that were in the selection.
 			for ( final V v : vertices )
+			{
+				if ( vSet.contains( v ) )
+					continue;
+
 				search.start( v );
+			}
 
 			// Select iterated stuff.
-			selection.setVerticesSelected( vList, true );
-			selection.setEdgesSelected( eList, true );
-
-
-			// TODO: the following seems wrong!!! no changes to the graph are made!!!
-			undo.setUndoPoint();
-			notify.notifyGraphChanged();
+			selection.setVerticesSelected( vSet, true );
+			selection.setEdgesSelected( eSet, true );
 			selection.resumeListeners();
 		}
 	}

--- a/src/test/java/org/mastodon/graph/features/calculator/EdgeFeatureCalculatorExample.java
+++ b/src/test/java/org/mastodon/graph/features/calculator/EdgeFeatureCalculatorExample.java
@@ -92,6 +92,10 @@ public class EdgeFeatureCalculatorExample
 					dr.add( tmp );
 					n.inc();
 				}
+
+				@Override
+				public void crossComponent( final Spot from, final Spot to, final DepthFirstSearch< Spot, Link > search )
+				{}
 			} );
 
 			linkCollector.start( root );


### PR DESCRIPTION
The content of this PR has been "manually" migrated to the `unify-views` branch by Tobias.

- [x] ` ScreenVertexMath` do not use AWT Ellipse class, but return ellipse parameters as a `double[]` array. We could even make it more general and remove the explicit dependency on `OverlayVertex` and just accept something that has a covariance and is `RealLocalizable`. I am sure this code is useful to a very wide audience.

- [x] Fix the `getVertexAt` method per @tpietzsch comments on how it should be in synch with what is painted. 

- [x] As @tpietzsch suggestion: moved the `ConvexPolytope` methods to utility class. 

- [x] Also made a PR in Imglib2 for symmetric matrix inversion system, so that we can remove this code from here.

- [x] Javadocs for methods and fields in OverlayGraphRenderer.

- [x] Fix and use the selection actions.  …
  - shift SPACE to select all edges/vertices in a track.
  - shift PAGE_UP for track upward selection.
  - shift PAGE_DOWN for track downward selection.