### PR TITLE
Feature de/serialization. DO NOT MERGE

### DIFF
--- a/src/main/java/org/mastodon/revised/mamut/FeatureComputersPanel.java
+++ b/src/main/java/org/mastodon/revised/mamut/FeatureComputersPanel.java
@@ -66,7 +66,7 @@ public class FeatureComputersPanel extends JPanel
 
 	private final MyProgressBar progressBar;
 
-	private final Set< FeatureComputer< Model > > selectedComputers;
+	private final Set< FeatureComputer< ?, ?, Model > > selectedComputers;
 
 	private final JButton btnCompute;
 
@@ -222,13 +222,13 @@ public class FeatureComputersPanel extends JPanel
 		return DATE_FORMAT.format( Calendar.getInstance().getTime() );
 	}
 
-	private void layoutComputers( final JPanel panel, final GridBagConstraints c, final Collection< FeatureComputer< Model > > set )
+	private void layoutComputers( final JPanel panel, final GridBagConstraints c, final Collection< FeatureComputer< ?, ?, Model > > set )
 	{
 		if ( set.isEmpty() )
 			return;
 
 		c.gridx = 0;
-		for ( final FeatureComputer< Model > computer : set )
+		for ( final FeatureComputer< ?, ?, Model > computer : set )
 		{
 			final boolean selected = true;
 			final JCheckBox checkBox = new JCheckBox( computer.getKey(), selected );

--- a/src/main/java/org/mastodon/revised/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/revised/mamut/MainWindow.java
@@ -26,7 +26,6 @@ import javax.swing.JSeparator;
 import javax.swing.WindowConstants;
 
 import org.mastodon.app.ui.ViewMenu;
-import org.mastodon.revised.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureModel;
 import org.mastodon.revised.model.feature.FeatureProjection;
@@ -48,11 +47,6 @@ public class MainWindow extends JFrame implements Contextual
 	public MainWindow( final WindowManager windowManager )
 	{
 		super( "Mastodon" );
-		/*
-		 * Instantiate context with required services.
-		 */
-		this.context = new Context( MamutFeatureComputerService.class );
-
 		/*
 		 * GUI
 		 */
@@ -161,7 +155,7 @@ public class MainWindow extends JFrame implements Contextual
 
 		final Container content = getContentPane();
 		content.add( buttonsPanel, BorderLayout.NORTH );
-
+		
 		menubar = new JMenuBar();
 		setJMenuBar( menubar );
 
@@ -223,10 +217,10 @@ public class MainWindow extends JFrame implements Contextual
 	protected static final String dump(final Model model)
 	{
 		final ModelGraph graph = model.getGraph();
-		final FeatureModel featureModel = model.getFeatureModel();
+		final FeatureModel< Model > featureModel = model.getFeatureModel();
 
 		final StringBuilder str = new StringBuilder();
-		str.append( "Model " + model.toString()  + "\n");
+		str.append( "Model " + model.toString() + "\n" );
 
 		/*
 		 * Collect spot feature headers.
@@ -234,9 +228,8 @@ public class MainWindow extends JFrame implements Contextual
 
 		final Map< String, FeatureProjection< Spot > > sfs = new LinkedHashMap<>();
 		Set< Feature< ?, ? > > spotFeatures = featureModel.getFeatureSet( Spot.class );
-		if (null == spotFeatures)
+		if ( null == spotFeatures )
 			spotFeatures = Collections.emptySet();
-
 
 		for ( final Feature< ?, ? > feature : spotFeatures )
 		{
@@ -265,7 +258,7 @@ public class MainWindow extends JFrame implements Contextual
 		}
 
 		str.append( '\n' );
-		final char[] sline = new char[h1a.length() + Arrays.stream( spotColumnHeaderWidth ).sum() + 2 * spotColumnHeaderWidth.length];
+		final char[] sline = new char[ h1a.length() + Arrays.stream( spotColumnHeaderWidth ).sum() + 2 * spotColumnHeaderWidth.length ];
 		Arrays.fill( sline, '-' );
 		str.append( sline );
 		str.append( '\n' );
@@ -280,7 +273,7 @@ public class MainWindow extends JFrame implements Contextual
 			i = 0;
 			for ( final String pn : sfs.keySet() )
 			{
-				if (sfs.get( pn ).isSet( spot ))
+				if ( sfs.get( pn ).isSet( spot ) )
 					str.append( String.format( "  %" + spotColumnHeaderWidth[ i ] + ".1f", sfs.get( pn ).value( spot ) ) );
 				else
 					str.append( String.format( "  %" + spotColumnHeaderWidth[ i ] + "s", "unset" ) );
@@ -295,9 +288,8 @@ public class MainWindow extends JFrame implements Contextual
 
 		final Map< String, FeatureProjection< Link > > lfs = new LinkedHashMap<>();
 		Set< Feature< ?, ? > > linkFeatures = featureModel.getFeatureSet( Link.class );
-		if (null == linkFeatures)
+		if ( null == linkFeatures )
 			linkFeatures = Collections.emptySet();
-
 
 		for ( final Feature< ?, ? > feature : linkFeatures )
 		{
@@ -325,7 +317,7 @@ public class MainWindow extends JFrame implements Contextual
 		}
 
 		str.append( '\n' );
-		final char[] lline = new char[h2a.length() + Arrays.stream( linkColumnHeaderWidth ).sum() + 2 * linkColumnHeaderWidth.length];
+		final char[] lline = new char[ h2a.length() + Arrays.stream( linkColumnHeaderWidth ).sum() + 2 * linkColumnHeaderWidth.length ];
 		Arrays.fill( lline, '-' );
 		str.append( lline );
 		str.append( '\n' );
@@ -334,12 +326,12 @@ public class MainWindow extends JFrame implements Contextual
 		for ( final Link link : graph.edges() )
 		{
 			final String h1b = String.format( "%9d  %9d  %9d", link.getInternalPoolIndex(),
-					link.getSource( ref ).getInternalPoolIndex(), link.getTarget(ref).getInternalPoolIndex() );
+					link.getSource( ref ).getInternalPoolIndex(), link.getTarget( ref ).getInternalPoolIndex() );
 			str.append( h1b );
 			i = 0;
 			for ( final String pn : lfs.keySet() )
 			{
-				if (lfs.get( pn ).isSet( link ))
+				if ( lfs.get( pn ).isSet( link ) )
 					str.append( String.format( "  %" + linkColumnHeaderWidth[ i ] + ".1f", lfs.get( pn ).value( link ) ) );
 				else
 					str.append( String.format( "  %" + linkColumnHeaderWidth[ i ] + "s", "unset" ) );

--- a/src/main/java/org/mastodon/revised/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/revised/mamut/MainWindow.java
@@ -21,8 +21,13 @@ import javax.swing.JSeparator;
 import javax.swing.WindowConstants;
 
 import org.mastodon.app.ui.ViewMenu;
+import org.mastodon.revised.mamut.feature.MamutFeatureComputerService;
+import org.scijava.Context;
+import org.scijava.Contextual;
+import org.scijava.NullContextException;
+import org.scijava.plugin.Parameter;
 
-public class MainWindow extends JFrame
+public class MainWindow extends JFrame implements Contextual
 {
 	protected final JMenuBar menubar;
 
@@ -31,6 +36,14 @@ public class MainWindow extends JFrame
 	public MainWindow( final WindowManager windowManager )
 	{
 		super( "Mastodon" );
+		/*
+		 * Instantiate context with required services.
+		 */
+		this.context = new Context( MamutFeatureComputerService.class );
+
+		/*
+		 * GUI
+		 */
 
 		final ActionMap actionMap = windowManager.getGlobalAppActions().getActionMap();
 
@@ -156,8 +169,23 @@ public class MainWindow extends JFrame
 //			}
 //		} );
 		setDefaultCloseOperation( WindowConstants.EXIT_ON_CLOSE );
-
 		pack();
+	}
+
+	// -- Contextual methods --
+
+	@Parameter
+	private Context context;
+
+	@Override
+	public Context context() {
+		if (context == null) throw new NullContextException();
+		return context;
+	}
+
+	@Override
+	public Context getContext() {
+		return context;
 	}
 
 	public static void addMenus( final ViewMenu menu, final ActionMap actionMap )

--- a/src/main/java/org/mastodon/revised/mamut/MainWindow.java
+++ b/src/main/java/org/mastodon/revised/mamut/MainWindow.java
@@ -10,6 +10,11 @@ import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.ActionMap;
 import javax.swing.JButton;
@@ -22,6 +27,13 @@ import javax.swing.WindowConstants;
 
 import org.mastodon.app.ui.ViewMenu;
 import org.mastodon.revised.mamut.feature.MamutFeatureComputerService;
+import org.mastodon.revised.model.feature.Feature;
+import org.mastodon.revised.model.feature.FeatureModel;
+import org.mastodon.revised.model.feature.FeatureProjection;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.ModelGraph;
+import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.Context;
 import org.scijava.Contextual;
 import org.scijava.NullContextException;
@@ -51,28 +63,28 @@ public class MainWindow extends JFrame implements Contextual
 		final GridBagLayout gbl = new GridBagLayout();
 		gbl.columnWeights = new double[] { 1.0, 1.0 };
 		gbl.rowWeights = new double[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-		buttonsPanel.setLayout(gbl);
+		buttonsPanel.setLayout( gbl );
 
 		final GridBagConstraints separator_gbc = new GridBagConstraints();
 		separator_gbc.fill = GridBagConstraints.HORIZONTAL;
 		separator_gbc.gridwidth = 2;
-		separator_gbc.insets = new Insets(5, 5, 5, 5);
+		separator_gbc.insets = new Insets( 5, 5, 5, 5 );
 		separator_gbc.gridx = 0;
 
 		final GridBagConstraints label_gbc = new GridBagConstraints();
 		label_gbc.fill = GridBagConstraints.HORIZONTAL;
 		label_gbc.gridwidth = 2;
-		label_gbc.insets = new Insets(5, 5, 5, 5);
+		label_gbc.insets = new Insets( 5, 5, 5, 5 );
 		label_gbc.gridx = 0;
 
 		final GridBagConstraints button_gbc_right = new GridBagConstraints();
 		button_gbc_right.fill = GridBagConstraints.BOTH;
-		button_gbc_right.insets = new Insets(0, 0, 5, 0);
+		button_gbc_right.insets = new Insets( 0, 0, 5, 0 );
 		button_gbc_right.gridx = 1;
 
 		final GridBagConstraints button_gbc_left = new GridBagConstraints();
 		button_gbc_left.fill = GridBagConstraints.BOTH;
-		button_gbc_left.insets = new Insets(0, 0, 5, 5);
+		button_gbc_left.insets = new Insets( 0, 0, 5, 5 );
 		button_gbc_left.gridx = 0;
 
 		int gridy = 0;
@@ -178,13 +190,16 @@ public class MainWindow extends JFrame implements Contextual
 	private Context context;
 
 	@Override
-	public Context context() {
-		if (context == null) throw new NullContextException();
+	public Context context()
+	{
+		if ( context == null )
+			throw new NullContextException();
 		return context;
 	}
 
 	@Override
-	public Context getContext() {
+	public Context getContext()
+	{
 		return context;
 	}
 
@@ -203,5 +218,136 @@ public class MainWindow extends JFrame implements Contextual
 						item( WindowManager.NEW_TRACKSCHEME_VIEW )
 				)
 		);
+	}
+
+	protected static final String dump(final Model model)
+	{
+		final ModelGraph graph = model.getGraph();
+		final FeatureModel featureModel = model.getFeatureModel();
+
+		final StringBuilder str = new StringBuilder();
+		str.append( "Model " + model.toString()  + "\n");
+
+		/*
+		 * Collect spot feature headers.
+		 */
+
+		final Map< String, FeatureProjection< Spot > > sfs = new LinkedHashMap<>();
+		Set< Feature< ?, ? > > spotFeatures = featureModel.getFeatureSet( Spot.class );
+		if (null == spotFeatures)
+			spotFeatures = Collections.emptySet();
+
+
+		for ( final Feature< ?, ? > feature : spotFeatures )
+		{
+			@SuppressWarnings( "unchecked" )
+			final Feature< Spot, ? > sf = ( Feature< Spot, ? > ) feature;
+			final Map< String, FeatureProjection< Spot > > projections = sf.getProjections();
+			sfs.putAll( projections );
+		}
+
+		/*
+		 * Loop over all spots.
+		 */
+
+		str.append( "Spots:\n" );
+		final String h1a = String.format( "%9s  %9s  %6s  %9s  %9s  %9s",
+				"Id", "Label", "Frame", "X", "Y", "Z" );
+		str.append( h1a );
+
+		final int[] spotColumnHeaderWidth = new int[ sfs.size() ];
+		int i = 0;
+		for ( final String pn : sfs.keySet() )
+		{
+			spotColumnHeaderWidth[ i ] = pn.length() + 2;
+			str.append( String.format( "  %" + spotColumnHeaderWidth[ i ] + "s", pn ) );
+			i++;
+		}
+
+		str.append( '\n' );
+		final char[] sline = new char[h1a.length() + Arrays.stream( spotColumnHeaderWidth ).sum() + 2 * spotColumnHeaderWidth.length];
+		Arrays.fill( sline, '-' );
+		str.append( sline );
+		str.append( '\n' );
+
+		for ( final Spot spot : graph.vertices() )
+		{
+			final String h1b = String.format( "%9d  %9s  %6d  %9.1f  %9.1f  %9.1f",
+					spot.getInternalPoolIndex(), spot.getLabel(), spot.getTimepoint(),
+					spot.getDoublePosition( 0 ), spot.getDoublePosition( 1 ), spot.getDoublePosition( 2 ) );
+
+			str.append( h1b );
+			i = 0;
+			for ( final String pn : sfs.keySet() )
+			{
+				if (sfs.get( pn ).isSet( spot ))
+					str.append( String.format( "  %" + spotColumnHeaderWidth[ i ] + ".1f", sfs.get( pn ).value( spot ) ) );
+				else
+					str.append( String.format( "  %" + spotColumnHeaderWidth[ i ] + "s", "unset" ) );
+				i++;
+			}
+			str.append( '\n' );
+		}
+
+		/*
+		 * Collect link feature headers.
+		 */
+
+		final Map< String, FeatureProjection< Link > > lfs = new LinkedHashMap<>();
+		Set< Feature< ?, ? > > linkFeatures = featureModel.getFeatureSet( Link.class );
+		if (null == linkFeatures)
+			linkFeatures = Collections.emptySet();
+
+
+		for ( final Feature< ?, ? > feature : linkFeatures )
+		{
+			@SuppressWarnings( "unchecked" )
+			final Feature< Link, ? > lf = ( Feature< Link, ? > ) feature;
+			final Map< String, FeatureProjection< Link > > projections = lf.getProjections();
+			lfs.putAll( projections );
+		}
+
+		/*
+		 * Loop over all links.
+		 */
+
+		str.append( "Links:\n" );
+		final String h2a = String.format( "%9s  %9s  %9s", "Id", "Source Id", "Target Id" );
+		str.append( h2a );
+
+		final int[] linkColumnHeaderWidth = new int[ lfs.size() ];
+		i = 0;
+		for ( final String pn : lfs.keySet() )
+		{
+			linkColumnHeaderWidth[ i ] = pn.length() + 2;
+			str.append( String.format( "  %" + linkColumnHeaderWidth[ i ] + "s", pn ) );
+			i++;
+		}
+
+		str.append( '\n' );
+		final char[] lline = new char[h2a.length() + Arrays.stream( linkColumnHeaderWidth ).sum() + 2 * linkColumnHeaderWidth.length];
+		Arrays.fill( lline, '-' );
+		str.append( lline );
+		str.append( '\n' );
+
+		final Spot ref = graph.vertexRef();
+		for ( final Link link : graph.edges() )
+		{
+			final String h1b = String.format( "%9d  %9d  %9d", link.getInternalPoolIndex(),
+					link.getSource( ref ).getInternalPoolIndex(), link.getTarget(ref).getInternalPoolIndex() );
+			str.append( h1b );
+			i = 0;
+			for ( final String pn : lfs.keySet() )
+			{
+				if (lfs.get( pn ).isSet( link ))
+					str.append( String.format( "  %" + linkColumnHeaderWidth[ i ] + ".1f", lfs.get( pn ).value( link ) ) );
+				else
+					str.append( String.format( "  %" + linkColumnHeaderWidth[ i ] + "s", "unset" ) );
+				i++;
+			}
+			str.append( '\n' );
+		}
+
+		return str.toString();
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/Mastodon.java
+++ b/src/main/java/org/mastodon/revised/mamut/Mastodon.java
@@ -44,7 +44,7 @@ public class Mastodon implements Command
 
 
 		final String bdvFile = "samples/datasethdf5.xml";
-		final MamutProject project = new MamutProject( new File( "samples/mamutproject" ), new File( bdvFile ) );
+		final MamutProject project = new MamutProject( new File( "samples/" ), new File( bdvFile ) );
 //		final MamutProject project = new MamutProjectIO().load( "samples/mamutproject" );
 
 		windowManager.projectManager.open( project );

--- a/src/main/java/org/mastodon/revised/mamut/feature/DefaultMamutFeatureComputerService.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/DefaultMamutFeatureComputerService.java
@@ -7,6 +7,7 @@ import org.scijava.plugin.Plugin;
 @Plugin(type = MamutFeatureComputerService.class)
 public class DefaultMamutFeatureComputerService extends AbstractFeatureComputerService< Model > implements MamutFeatureComputerService
 {
+	@SuppressWarnings( "unchecked" )
 	@Override
 	public void initialize()
 	{

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
@@ -1,17 +1,11 @@
 package org.mastodon.revised.mamut.feature;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.FileIdToObjectMap;
-import org.mastodon.io.properties.DoublePropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
-import org.mastodon.revised.model.feature.FeatureProjection;
-import org.mastodon.revised.model.feature.FeatureProjectors;
+import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
@@ -19,7 +13,7 @@ import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
 @Plugin( type = LinkFeatureComputer.class, name = "Link displacement" )
-public class LinkDisplacementComputer implements LinkFeatureComputer
+public class LinkDisplacementComputer implements LinkFeatureComputer< DoublePropertyMap< Link > >
 {
 
 	public static final String KEY = "Link displacement";
@@ -61,36 +55,12 @@ public class LinkDisplacementComputer implements LinkFeatureComputer
 		graph.releaseRef( ref1 );
 		graph.releaseRef( ref2 );
 
-		return bundle( pm );
+		return MamutFeatureSerializers.bundle( KEY, pm, Link.class );
 	}
 
 	@Override
-	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
+	public FeatureSerializer< Link, DoublePropertyMap< Link >, Model > getSerializer()
 	{
-		final DoublePropertyMap< Link > pm = new DoublePropertyMap<>( model.getGraph().edges(), Double.NaN );
-		final DoublePropertyMapSerializer< Link > serializer = new DoublePropertyMapSerializer<>( pm );
-		@SuppressWarnings( "unchecked" )
-		final FileIdToObjectMap< Link > idmap = ( FileIdToObjectMap< Link > ) fileIdToObjectMap;
-		try
-		{
-			serializer.readPropertyMap( idmap, ois );
-		}
-		catch ( ClassNotFoundException | IOException e1 )
-		{
-			e1.printStackTrace();
-		}
-		return bundle( pm );
-	}
-
-	private Feature< Link, DoublePropertyMap< Link > > bundle( final DoublePropertyMap< Link > propertyMap )
-	{
-		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( propertyMap ) );
-		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>(
-				KEY,
-				Link.class,
-				propertyMap,
-				projections,
-				new DoublePropertyMapSerializer<>( propertyMap ) );
-		return feature;
+		return MamutFeatureSerializers.doubleLinkSerializer(KEY);
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
@@ -3,9 +3,10 @@ package org.mastodon.revised.mamut.feature;
 import java.util.Collections;
 import java.util.Set;
 
+import org.mastodon.io.properties.DoublePropertyMapSerializer;
+import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
-import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
@@ -59,8 +60,15 @@ public class LinkDisplacementComputer implements LinkFeatureComputer< DoubleProp
 	}
 
 	@Override
-	public FeatureSerializer< Link, DoublePropertyMap< Link >, Model > getSerializer()
+	public PropertyMapSerializer< Link, DoublePropertyMap< Link > > getSerializer( final DoublePropertyMap< Link > pm )
 	{
-		return MamutFeatureSerializers.doubleLinkSerializer(KEY);
+		return new DoublePropertyMapSerializer<>( pm );
 	}
+
+	@Override
+	public DoublePropertyMap< Link > createPropertyMap( final Model model )
+	{
+		return new DoublePropertyMap< Link >( model.getGraph().edges(), Double.NaN, model.getGraph().edges().size() );
+	}
+
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.io.properties.DoublePropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureProjection;
@@ -58,7 +59,12 @@ public class LinkDisplacementComputer implements LinkFeatureComputer
 		graph.releaseRef( ref2 );
 
 		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( pm ) );
-		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>( KEY, Link.class, pm, projections );
+		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>(
+				KEY,
+				Link.class,
+				pm,
+				projections,
+				new DoublePropertyMapSerializer<>( pm ) );
 		return feature;
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkDisplacementComputer.java
@@ -3,10 +3,9 @@ package org.mastodon.revised.mamut.feature;
 import java.util.Collections;
 import java.util.Set;
 
-import org.mastodon.io.properties.DoublePropertyMapSerializer;
-import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
+import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
@@ -60,15 +59,9 @@ public class LinkDisplacementComputer implements LinkFeatureComputer< DoubleProp
 	}
 
 	@Override
-	public PropertyMapSerializer< Link, DoublePropertyMap< Link > > getSerializer( final DoublePropertyMap< Link > pm )
+	public FeatureSerializer< Link, DoublePropertyMap< Link >, Model > getSerializer()
 	{
-		return new DoublePropertyMapSerializer<>( pm );
-	}
-
-	@Override
-	public DoublePropertyMap< Link > createPropertyMap( final Model model )
-	{
-		return new DoublePropertyMap< Link >( model.getGraph().edges(), Double.NaN, model.getGraph().edges().size() );
+		return MamutFeatureSerializers.doubleLinkSerializer( KEY );
 	}
 
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkFeatureComputer.java
@@ -1,6 +1,8 @@
 package org.mastodon.revised.mamut.feature;
 
+import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.feature.FeatureComputer;
+import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 
 /**
@@ -9,5 +11,5 @@ import org.mastodon.revised.model.mamut.Model;
  *
  * @author Jean-Yves Tinevez
  */
-public interface LinkFeatureComputer extends FeatureComputer< Model >
+public interface LinkFeatureComputer< M extends PropertyMap< Link, ? > > extends FeatureComputer< Link, M, Model >
 {}

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
@@ -1,17 +1,11 @@
 package org.mastodon.revised.mamut.feature;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.FileIdToObjectMap;
-import org.mastodon.io.properties.DoublePropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
-import org.mastodon.revised.model.feature.FeatureProjection;
-import org.mastodon.revised.model.feature.FeatureProjectors;
+import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Link;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.ModelGraph;
@@ -19,7 +13,7 @@ import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
 @Plugin( type = LinkFeatureComputer.class, name = "Link velocity" )
-public class LinkVelocityFeatureComputer implements LinkFeatureComputer
+public class LinkVelocityFeatureComputer implements LinkFeatureComputer< DoublePropertyMap< Link > >
 {
 
 	public static final String KEY = "Link velocity";
@@ -65,36 +59,13 @@ public class LinkVelocityFeatureComputer implements LinkFeatureComputer
 		graph.releaseRef( ref1 );
 		graph.releaseRef( ref2 );
 
-		return bundle( pm );
+		return MamutFeatureSerializers.bundle( KEY, pm, Link.class );
 	}
 
 	@Override
-	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
+	public FeatureSerializer< Link, DoublePropertyMap< Link >, Model > getSerializer()
 	{
-		final DoublePropertyMap< Link > pm = new DoublePropertyMap<>( model.getGraph().edges(), Double.NaN );
-		final DoublePropertyMapSerializer< Link > serializer = new DoublePropertyMapSerializer<>( pm );
-		@SuppressWarnings( "unchecked" )
-		final FileIdToObjectMap< Link > idmap = ( FileIdToObjectMap< Link > ) fileIdToObjectMap;
-		try
-		{
-			serializer.readPropertyMap( idmap, ois );
-		}
-		catch ( ClassNotFoundException | IOException e1 )
-		{
-			e1.printStackTrace();
-		}
-		return bundle( pm );
+		return MamutFeatureSerializers.doubleLinkSerializer( KEY );
 	}
 
-	private Feature< Link, DoublePropertyMap< Link > > bundle( final DoublePropertyMap< Link > propertyMap )
-	{
-		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( propertyMap ) );
-		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>(
-				KEY,
-				Link.class,
-				propertyMap,
-				projections,
-				new DoublePropertyMapSerializer<>( propertyMap ) );
-		return feature;
-	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
@@ -1,9 +1,12 @@
 package org.mastodon.revised.mamut.feature;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.io.properties.DoublePropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -62,13 +65,36 @@ public class LinkVelocityFeatureComputer implements LinkFeatureComputer
 		graph.releaseRef( ref1 );
 		graph.releaseRef( ref2 );
 
-		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( pm ) );
+		return bundle( pm );
+	}
+
+	@Override
+	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
+	{
+		final DoublePropertyMap< Link > pm = new DoublePropertyMap<>( model.getGraph().edges(), Double.NaN );
+		final DoublePropertyMapSerializer< Link > serializer = new DoublePropertyMapSerializer<>( pm );
+		@SuppressWarnings( "unchecked" )
+		final FileIdToObjectMap< Link > idmap = ( FileIdToObjectMap< Link > ) fileIdToObjectMap;
+		try
+		{
+			serializer.readPropertyMap( idmap, ois );
+		}
+		catch ( ClassNotFoundException | IOException e1 )
+		{
+			e1.printStackTrace();
+		}
+		return bundle( pm );
+	}
+
+	private Feature< Link, DoublePropertyMap< Link > > bundle( final DoublePropertyMap< Link > propertyMap )
+	{
+		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( propertyMap ) );
 		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>(
 				KEY,
 				Link.class,
-				pm,
+				propertyMap,
 				projections,
-				new DoublePropertyMapSerializer<>( pm ));
+				new DoublePropertyMapSerializer<>( propertyMap ) );
 		return feature;
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/LinkVelocityFeatureComputer.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.io.properties.DoublePropertyMapSerializer;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureProjection;
@@ -62,7 +63,12 @@ public class LinkVelocityFeatureComputer implements LinkFeatureComputer
 		graph.releaseRef( ref2 );
 
 		final Map< String, FeatureProjection< Link > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( pm ) );
-		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>( KEY, Link.class, pm, projections );
+		final Feature< Link, DoublePropertyMap< Link > > feature = new Feature<>(
+				KEY,
+				Link.class,
+				pm,
+				projections,
+				new DoublePropertyMapSerializer<>( pm ));
 		return feature;
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
@@ -1,31 +1,14 @@
 package org.mastodon.revised.mamut.feature;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Collections;
 import java.util.Map;
 
-import org.mastodon.RefPool;
-import org.mastodon.collection.RefDoubleMap;
-import org.mastodon.collection.RefIntMap;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureProjection;
 import org.mastodon.revised.model.feature.FeatureProjectors;
 import org.mastodon.revised.model.feature.FeatureSerializer;
-import org.mastodon.revised.model.mamut.Link;
-import org.mastodon.revised.model.mamut.Model;
-import org.mastodon.revised.model.mamut.Spot;
-
-import gnu.trove.map.hash.TIntDoubleHashMap;
-import gnu.trove.map.hash.TIntIntHashMap;
 
 /**
  * Utility {@link FeatureSerializer}s for MaMuT.
@@ -35,57 +18,57 @@ import gnu.trove.map.hash.TIntIntHashMap;
 public class MamutFeatureSerializers
 {
 
-	/**
-	 * Returns a serializer able to de/serialize a <code>double</code> feature
-	 * defined on {@link Link}.
-	 *
-	 * @param featureKey
-	 *            the feature key.
-	 * @return a new feature serializer.
-	 */
-	public static FeatureSerializer< Link, DoublePropertyMap< Link >, Model > doubleLinkSerializer( final String featureKey )
-	{
-		return new DoubleLinkFeatureSerializer( featureKey );
-	}
-
-	/**
-	 * Returns a serializer able to de/serialize a <code>double</code> feature
-	 * defined on {@link Spot}.
-	 *
-	 * @param featureKey
-	 *            the feature key.
-	 * @return a new feature serializer.
-	 */
-	public static FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model > doubleSpotSerializer( final String featureKey )
-	{
-		return new DoubleSpotFeatureSerializer( featureKey );
-	}
-
-	/**
-	 * Returns a serializer able to de/serialize a <code>in</code> feature
-	 * defined on {@link Spot}.
-	 *
-	 * @param featureKey
-	 *            the feature key.
-	 * @return a new feature serializer.
-	 */
-	public static FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > intSpotSerializer( final String featureKey )
-	{
-		return new IntSpotFeatureSerializer( featureKey );
-	}
-
-	/**
-	 * Returns a serializer able to de/serialize a <code>in</code> feature
-	 * defined on {@link Link}.
-	 *
-	 * @param featureKey
-	 *            the feature key.
-	 * @return a new feature serializer.
-	 */
-	public static FeatureSerializer< Link, IntPropertyMap< Link >, Model > intLinkSerializer( final String featureKey )
-	{
-		return new IntLinkFeatureSerializer( featureKey );
-	}
+//	/**
+//	 * Returns a serializer able to de/serialize a <code>double</code> feature
+//	 * defined on {@link Link}.
+//	 *
+//	 * @param featureKey
+//	 *            the feature key.
+//	 * @return a new feature serializer.
+//	 */
+//	public static FeatureSerializer< Link, DoublePropertyMap< Link >, Model > doubleLinkSerializer( final String featureKey )
+//	{
+//		return new DoubleLinkFeatureSerializer( featureKey );
+//	}
+//
+//	/**
+//	 * Returns a serializer able to de/serialize a <code>double</code> feature
+//	 * defined on {@link Spot}.
+//	 *
+//	 * @param featureKey
+//	 *            the feature key.
+//	 * @return a new feature serializer.
+//	 */
+//	public static FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model > doubleSpotSerializer( final String featureKey )
+//	{
+//		return new DoubleSpotFeatureSerializer( featureKey );
+//	}
+//
+//	/**
+//	 * Returns a serializer able to de/serialize a <code>in</code> feature
+//	 * defined on {@link Spot}.
+//	 *
+//	 * @param featureKey
+//	 *            the feature key.
+//	 * @return a new feature serializer.
+//	 */
+//	public static FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > intSpotSerializer( final String featureKey )
+//	{
+//		return new IntSpotFeatureSerializer( featureKey );
+//	}
+//
+//	/**
+//	 * Returns a serializer able to de/serialize a <code>in</code> feature
+//	 * defined on {@link Link}.
+//	 *
+//	 * @param featureKey
+//	 *            the feature key.
+//	 * @return a new feature serializer.
+//	 */
+//	public static FeatureSerializer< Link, IntPropertyMap< Link >, Model > intLinkSerializer( final String featureKey )
+//	{
+//		return new IntLinkFeatureSerializer( featureKey );
+//	}
 
 	public static final < O > Feature< O, DoublePropertyMap< O > > bundle( final String featureKey, final DoublePropertyMap< O > propertyMap, final Class< O > clazz )
 	{
@@ -109,192 +92,194 @@ public class MamutFeatureSerializers
 		return feature;
 	}
 
-	/*
-	 * INNER CLASSES
-	 */
+//
+//	/*
+//	 * INNER CLASSES
+//	 */
+//
+//	private static final class DoubleSpotFeatureSerializer implements FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model >
+//	{
+//
+//		private final String featureKey;
+//
+//		public DoubleSpotFeatureSerializer( final String featureKey )
+//		{
+//			this.featureKey = featureKey;
+//		}
+//
+//		@Override
+//		public void serialize( final Feature< Spot, DoublePropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
+//		{
+//			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
+//		}
+//
+//		@Override
+//		public Feature< Spot, DoublePropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
+//		{
+//			final DoublePropertyMap< Spot > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().vertices().getRefPool(), Double.NaN );
+//			return bundle( featureKey, propertyMap, Spot.class );
+//		}
+//	}
+//
+//	private static final class DoubleLinkFeatureSerializer implements FeatureSerializer< Link, DoublePropertyMap< Link >, Model >
+//	{
+//
+//		private final String featureKey;
+//
+//		public DoubleLinkFeatureSerializer( final String featureKey )
+//		{
+//			this.featureKey = featureKey;
+//		}
+//
+//		@Override
+//		public void serialize( final Feature< Link, DoublePropertyMap< Link > > feature, final File file, final Model model ) throws IOException
+//		{
+//			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
+//		}
+//
+//		@Override
+//		public Feature< Link, DoublePropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
+//		{
+//			final DoublePropertyMap< Link > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().edges().getRefPool(), Double.NaN );
+//			return bundle( featureKey, propertyMap, Link.class );
+//		}
+//
+//	}
+//
+//	private static final class IntSpotFeatureSerializer implements FeatureSerializer< Spot, IntPropertyMap< Spot >, Model >
+//	{
+//
+//		private final String featureKey;
+//
+//		public IntSpotFeatureSerializer( final String featureKey )
+//		{
+//			this.featureKey = featureKey;
+//		}
+//
+//		@Override
+//		public void serialize( final Feature< Spot, IntPropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
+//		{
+//			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
+//		}
+//
+//		@Override
+//		public Feature< Spot, IntPropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
+//		{
+//			final IntPropertyMap< Spot > pm = deserializeIntPropertyMap( file, model.getGraph().vertices().getRefPool(), Integer.MIN_VALUE );
+//			return bundle( featureKey, pm, Spot.class );
+//		}
+//	}
+//
+//	private static final class IntLinkFeatureSerializer implements FeatureSerializer< Link, IntPropertyMap< Link >, Model >
+//	{
+//
+//		private final String featureKey;
+//
+//		public IntLinkFeatureSerializer( final String featureKey )
+//		{
+//			this.featureKey = featureKey;
+//		}
+//
+//		@Override
+//		public void serialize( final Feature< Link, IntPropertyMap< Link > > feature, final File file, final Model model ) throws IOException
+//		{
+//			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
+//		}
+//
+//		@Override
+//		public Feature< Link, IntPropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
+//		{
+//			final IntPropertyMap< Link > pm = deserializeIntPropertyMap( file, model.getGraph().edges().getRefPool(), Integer.MIN_VALUE );
+//			return bundle( featureKey, pm, Link.class );
+//		}
+//	}
+//
+//	private static final < O > void serializeIntPropertyMap( final File file, final IntPropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
+//	{
+//		try (final ObjectOutputStream oos =
+//				new ObjectOutputStream(
+//						new BufferedOutputStream(
+//								new FileOutputStream( file ), 1024 * 1024 ) ))
+//		{
+//			final TIntIntHashMap fmap = new TIntIntHashMap();
+//			final RefIntMap< O > pmap = propertyMap.getMap();
+//			pmap.forEachEntry( ( final O key, final int value ) -> {
+//				fmap.put( pool.getId( key ), value );
+//				return true;
+//			} );
+//			oos.writeObject( fmap );
+//		}
+//	}
+//
+//	private static final < O > void serializeDoublePropertyMap( final File file, final DoublePropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
+//	{
+//		try (final ObjectOutputStream oos =
+//				new ObjectOutputStream(
+//						new BufferedOutputStream(
+//								new FileOutputStream( file ), 1024 * 1024 ) ))
+//		{
+//			final TIntDoubleHashMap fmap = new TIntDoubleHashMap();
+//			final RefDoubleMap< O > pmap = propertyMap.getMap();
+//			pmap.forEachEntry( ( final O key, final double value ) -> {
+//				fmap.put( pool.getId( key ), value );
+//				return true;
+//			} );
+//			oos.writeObject( fmap );
+//		}
+//	}
+//
+//	private static final < O > IntPropertyMap< O > deserializeIntPropertyMap( final File file, final RefPool< O > pool, final int noEntry ) throws IOException
+//	{
+//		try (final ObjectInputStream ois =
+//				new ObjectInputStream(
+//						new BufferedInputStream(
+//								new FileInputStream( file ), 1024 * 1024 ) ))
+//		{
+//			final TIntIntHashMap fmap = ( TIntIntHashMap ) ois.readObject();
+//			final IntPropertyMap< O > pm = new IntPropertyMap<>( pool, noEntry );
+//			final RefIntMap< O > pmap = pm.getMap();
+//			pmap.clear();
+//			final O ref = pool.createRef();
+//			fmap.forEachEntry( ( final int key, final int value ) -> {
+//				pmap.put( pool.getObject( key, ref ), value );
+//				return true;
+//			} );
+//			pool.releaseRef( ref );
+//			return pm;
+//		}
+//		catch ( final ClassNotFoundException e )
+//		{
+//			e.printStackTrace();
+//		}
+//		return null;
+//	}
+//
+//	private static final < O > DoublePropertyMap< O > deserializeDoublePropertyMap( final File file, final RefPool< O > pool, final double noEntry ) throws IOException
+//	{
+//		try (final ObjectInputStream ois =
+//				new ObjectInputStream(
+//						new BufferedInputStream(
+//								new FileInputStream( file ), 1024 * 1024 ) ))
+//		{
+//			final TIntDoubleHashMap fmap = ( TIntDoubleHashMap ) ois.readObject();
+//			final DoublePropertyMap< O > pm = new DoublePropertyMap<>( pool, noEntry );
+//			final RefDoubleMap< O > pmap = pm.getMap();
+//			pmap.clear();
+//			final O ref = pool.createRef();
+//			fmap.forEachEntry( ( final int key, final double value ) -> {
+//				pmap.put( pool.getObject( key, ref ), value );
+//				return true;
+//			} );
+//			pool.releaseRef( ref );
+//			return pm;
+//		}
+//		catch ( final ClassNotFoundException e )
+//		{
+//			e.printStackTrace();
+//		}
+//		return null;
+//	}
 
-	private static final class DoubleSpotFeatureSerializer implements FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model >
-	{
-
-		private final String featureKey;
-
-		public DoubleSpotFeatureSerializer( final String featureKey )
-		{
-			this.featureKey = featureKey;
-		}
-
-		@Override
-		public void serialize( final Feature< Spot, DoublePropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
-		{
-			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
-		}
-
-		@Override
-		public Feature< Spot, DoublePropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
-		{
-			final DoublePropertyMap< Spot > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().vertices().getRefPool(), Double.NaN );
-			return bundle( featureKey, propertyMap, Spot.class );
-		}
-	}
-
-	private static final class DoubleLinkFeatureSerializer implements FeatureSerializer< Link, DoublePropertyMap< Link >, Model >
-	{
-
-		private final String featureKey;
-
-		public DoubleLinkFeatureSerializer( final String featureKey )
-		{
-			this.featureKey = featureKey;
-		}
-
-		@Override
-		public void serialize( final Feature< Link, DoublePropertyMap< Link > > feature, final File file, final Model model ) throws IOException
-		{
-			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
-		}
-
-		@Override
-		public Feature< Link, DoublePropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
-		{
-			final DoublePropertyMap< Link > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().edges().getRefPool(), Double.NaN );
-			return bundle( featureKey, propertyMap, Link.class );
-		}
-
-	}
-
-	private static final class IntSpotFeatureSerializer implements FeatureSerializer< Spot, IntPropertyMap< Spot >, Model >
-	{
-
-		private final String featureKey;
-
-		public IntSpotFeatureSerializer( final String featureKey )
-		{
-			this.featureKey = featureKey;
-		}
-
-		@Override
-		public void serialize( final Feature< Spot, IntPropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
-		{
-			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
-		}
-
-		@Override
-		public Feature< Spot, IntPropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
-		{
-			final IntPropertyMap< Spot > pm = deserializeIntPropertyMap( file, model.getGraph().vertices().getRefPool(), Integer.MIN_VALUE );
-			return bundle( featureKey, pm, Spot.class );
-		}
-	}
-
-	private static final class IntLinkFeatureSerializer implements FeatureSerializer< Link, IntPropertyMap< Link >, Model >
-	{
-
-		private final String featureKey;
-
-		public IntLinkFeatureSerializer( final String featureKey )
-		{
-			this.featureKey = featureKey;
-		}
-
-		@Override
-		public void serialize( final Feature< Link, IntPropertyMap< Link > > feature, final File file, final Model model ) throws IOException
-		{
-			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
-		}
-
-		@Override
-		public Feature< Link, IntPropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
-		{
-			final IntPropertyMap< Link > pm = deserializeIntPropertyMap( file, model.getGraph().edges().getRefPool(), Integer.MIN_VALUE );
-			return bundle( featureKey, pm, Link.class );
-		}
-	}
-
-	private static final < O > void serializeIntPropertyMap( final File file, final IntPropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
-	{
-		try (final ObjectOutputStream oos =
-				new ObjectOutputStream(
-						new BufferedOutputStream(
-								new FileOutputStream( file ), 1024 * 1024 ) ))
-		{
-			final TIntIntHashMap fmap = new TIntIntHashMap();
-			final RefIntMap< O > pmap = propertyMap.getMap();
-			pmap.forEachEntry( ( final O key, final int value ) -> {
-				fmap.put( pool.getId( key ), value );
-				return true;
-			} );
-			oos.writeObject( fmap );
-		}
-	}
-
-	private static final < O > void serializeDoublePropertyMap( final File file, final DoublePropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
-	{
-		try (final ObjectOutputStream oos =
-				new ObjectOutputStream(
-						new BufferedOutputStream(
-								new FileOutputStream( file ), 1024 * 1024 ) ))
-		{
-			final TIntDoubleHashMap fmap = new TIntDoubleHashMap();
-			final RefDoubleMap< O > pmap = propertyMap.getMap();
-			pmap.forEachEntry( ( final O key, final double value ) -> {
-				fmap.put( pool.getId( key ), value );
-				return true;
-			} );
-			oos.writeObject( fmap );
-		}
-	}
-
-	private static final < O > IntPropertyMap< O > deserializeIntPropertyMap( final File file, final RefPool< O > pool, final int noEntry ) throws IOException
-	{
-		try (final ObjectInputStream ois =
-				new ObjectInputStream(
-						new BufferedInputStream(
-								new FileInputStream( file ), 1024 * 1024 ) ))
-		{
-			final TIntIntHashMap fmap = ( TIntIntHashMap ) ois.readObject();
-			final IntPropertyMap< O > pm = new IntPropertyMap<>( pool, noEntry );
-			final RefIntMap< O > pmap = pm.getMap();
-			pmap.clear();
-			final O ref = pool.createRef();
-			fmap.forEachEntry( ( final int key, final int value ) -> {
-				pmap.put( pool.getObject( key, ref ), value );
-				return true;
-			} );
-			pool.releaseRef( ref );
-			return pm;
-		}
-		catch ( final ClassNotFoundException e )
-		{
-			e.printStackTrace();
-		}
-		return null;
-	}
-
-	private static final < O > DoublePropertyMap< O > deserializeDoublePropertyMap( final File file, final RefPool< O > pool, final double noEntry ) throws IOException
-	{
-		try (final ObjectInputStream ois =
-				new ObjectInputStream(
-						new BufferedInputStream(
-								new FileInputStream( file ), 1024 * 1024 ) ))
-		{
-			final TIntDoubleHashMap fmap = ( TIntDoubleHashMap ) ois.readObject();
-			final DoublePropertyMap< O > pm = new DoublePropertyMap<>( pool, noEntry );
-			final RefDoubleMap< O > pmap = pm.getMap();
-			pmap.clear();
-			final O ref = pool.createRef();
-			fmap.forEachEntry( ( final int key, final double value ) -> {
-				pmap.put( pool.getObject( key, ref ), value );
-				return true;
-			} );
-			pool.releaseRef( ref );
-			return pm;
-		}
-		catch ( final ClassNotFoundException e )
-		{
-			e.printStackTrace();
-		}
-		return null;
-	}
 
 	private MamutFeatureSerializers()
 	{}

--- a/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
@@ -1,14 +1,32 @@
 package org.mastodon.revised.mamut.feature;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collections;
 import java.util.Map;
 
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.io.properties.DoublePropertyMapSerializer;
+import org.mastodon.io.properties.IntPropertyMapSerializer;
+import org.mastodon.pool.PoolCollectionWrapper;
 import org.mastodon.properties.DoublePropertyMap;
 import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureProjection;
 import org.mastodon.revised.model.feature.FeatureProjectors;
 import org.mastodon.revised.model.feature.FeatureSerializer;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.Spot;
 
 /**
  * Utility {@link FeatureSerializer}s for MaMuT.
@@ -18,57 +36,182 @@ import org.mastodon.revised.model.feature.FeatureSerializer;
 public class MamutFeatureSerializers
 {
 
-//	/**
-//	 * Returns a serializer able to de/serialize a <code>double</code> feature
-//	 * defined on {@link Link}.
-//	 *
-//	 * @param featureKey
-//	 *            the feature key.
-//	 * @return a new feature serializer.
-//	 */
-//	public static FeatureSerializer< Link, DoublePropertyMap< Link >, Model > doubleLinkSerializer( final String featureKey )
-//	{
-//		return new DoubleLinkFeatureSerializer( featureKey );
-//	}
-//
-//	/**
-//	 * Returns a serializer able to de/serialize a <code>double</code> feature
-//	 * defined on {@link Spot}.
-//	 *
-//	 * @param featureKey
-//	 *            the feature key.
-//	 * @return a new feature serializer.
-//	 */
-//	public static FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model > doubleSpotSerializer( final String featureKey )
-//	{
-//		return new DoubleSpotFeatureSerializer( featureKey );
-//	}
-//
-//	/**
-//	 * Returns a serializer able to de/serialize a <code>in</code> feature
-//	 * defined on {@link Spot}.
-//	 *
-//	 * @param featureKey
-//	 *            the feature key.
-//	 * @return a new feature serializer.
-//	 */
-//	public static FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > intSpotSerializer( final String featureKey )
-//	{
-//		return new IntSpotFeatureSerializer( featureKey );
-//	}
-//
-//	/**
-//	 * Returns a serializer able to de/serialize a <code>in</code> feature
-//	 * defined on {@link Link}.
-//	 *
-//	 * @param featureKey
-//	 *            the feature key.
-//	 * @return a new feature serializer.
-//	 */
-//	public static FeatureSerializer< Link, IntPropertyMap< Link >, Model > intLinkSerializer( final String featureKey )
-//	{
-//		return new IntLinkFeatureSerializer( featureKey );
-//	}
+	public static final FeatureSerializer< Link, DoublePropertyMap< Link >, Model > doubleLinkSerializer( final String key )
+	{
+		return new FeatureSerializer< Link, DoublePropertyMap< Link >, Model >()
+		{
+
+			@Override
+			public void serialize( final Feature< Link, DoublePropertyMap< Link > > feature, final File file, final Model support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException
+			{
+				try (final ObjectOutputStream oos = new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+				{
+					final DoublePropertyMap< Link > pm = feature.getPropertyMap();
+					final DoublePropertyMapSerializer< Link > serializer = new DoublePropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final ObjectToFileIdMap< Link > linkToIdMap = ( ObjectToFileIdMap< Link > ) idmap.edges();
+					serializer.writePropertyMap( linkToIdMap, oos );
+				}
+			}
+
+			@Override
+			public Feature< Link, DoublePropertyMap< Link > > deserialize( final File file, final Model model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException
+			{
+				try (final ObjectInputStream ois = new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+				{
+					final PoolCollectionWrapper< Link > edges = model.getGraph().edges();
+					final DoublePropertyMap< Link > pm = new DoublePropertyMap<>( edges, Double.NaN, edges.size() );
+					final DoublePropertyMapSerializer< Link > serializer = new DoublePropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final FileIdToObjectMap< Link > idToLinkMap = ( FileIdToObjectMap< Link > ) fileIdToGraphMap.edges();
+					serializer.readPropertyMap( idToLinkMap, ois );
+					return MamutFeatureSerializers.bundle( key, pm, Link.class );
+				}
+				catch ( final ClassNotFoundException e )
+				{
+					e.printStackTrace();
+				}
+				return null;
+			}
+		};
+	}
+
+	public static final FeatureSerializer< Link, IntPropertyMap< Link >, Model > intLinkSerializer( final String key )
+	{
+		return new FeatureSerializer< Link, IntPropertyMap< Link >, Model >()
+		{
+
+			@Override
+			public void serialize( final Feature< Link, IntPropertyMap< Link > > feature, final File file, final Model support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException
+			{
+				try (final ObjectOutputStream oos = new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+				{
+					final IntPropertyMap< Link > pm = feature.getPropertyMap();
+					final IntPropertyMapSerializer< Link > serializer = new IntPropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final ObjectToFileIdMap< Link > linkToIdMap = ( ObjectToFileIdMap< Link > ) idmap.edges();
+					serializer.writePropertyMap( linkToIdMap, oos );
+				}
+			}
+
+			@Override
+			public Feature< Link, IntPropertyMap< Link > > deserialize( final File file, final Model model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException
+			{
+				try (final ObjectInputStream ois = new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+				{
+					final PoolCollectionWrapper< Link > edges = model.getGraph().edges();
+					final IntPropertyMap< Link > pm = new IntPropertyMap<>( edges, Integer.MIN_VALUE, edges.size() );
+					final IntPropertyMapSerializer< Link > serializer = new IntPropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final FileIdToObjectMap< Link > idToLinkMap = ( FileIdToObjectMap< Link > ) fileIdToGraphMap.edges();
+					serializer.readPropertyMap( idToLinkMap, ois );
+					return MamutFeatureSerializers.bundle( key, pm, Link.class );
+				}
+				catch ( final ClassNotFoundException e )
+				{
+					e.printStackTrace();
+				}
+				return null;
+			}
+		};
+	}
+
+	public static FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > intSpotSerializer( final String key )
+	{
+		return new FeatureSerializer< Spot, IntPropertyMap< Spot >, Model >()
+		{
+
+			@Override
+			public void serialize( final Feature< Spot, IntPropertyMap< Spot > > feature, final File file, final Model support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException
+			{
+				try (final ObjectOutputStream oos = new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+				{
+					final IntPropertyMap< Spot > pm = feature.getPropertyMap();
+					final IntPropertyMapSerializer< Spot > serializer = new IntPropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final ObjectToFileIdMap< Spot > linkToIdMap = ( ObjectToFileIdMap< Spot > ) idmap.vertices();
+					serializer.writePropertyMap( linkToIdMap, oos );
+				}
+			}
+
+			@Override
+			public Feature< Spot, IntPropertyMap< Spot > > deserialize( final File file, final Model model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException
+			{
+				try (final ObjectInputStream ois = new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+				{
+					final PoolCollectionWrapper< Spot > spots = model.getGraph().vertices();
+					final IntPropertyMap< Spot > pm = new IntPropertyMap<>( spots, Integer.MIN_VALUE, spots.size() );
+					final IntPropertyMapSerializer< Spot > serializer = new IntPropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final FileIdToObjectMap< Spot > idToLinkMap = ( FileIdToObjectMap< Spot > ) fileIdToGraphMap.vertices();
+					serializer.readPropertyMap( idToLinkMap, ois );
+					return MamutFeatureSerializers.bundle( key, pm, Spot.class );
+				}
+				catch ( final ClassNotFoundException e )
+				{
+					e.printStackTrace();
+				}
+				return null;
+			}
+		};
+	}
+
+	public static FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model > doubleSpotSerializer( final String key )
+	{
+		return new FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model >()
+		{
+
+			@Override
+			public void serialize( final Feature< Spot, DoublePropertyMap< Spot > > feature, final File file, final Model support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException
+			{
+				try (final ObjectOutputStream oos = new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+				{
+					final DoublePropertyMap< Spot > pm = feature.getPropertyMap();
+					final DoublePropertyMapSerializer< Spot > serializer = new DoublePropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final ObjectToFileIdMap< Spot > linkToIdMap = ( ObjectToFileIdMap< Spot > ) idmap.vertices();
+					serializer.writePropertyMap( linkToIdMap, oos );
+				}
+			}
+
+			@Override
+			public Feature< Spot, DoublePropertyMap< Spot > > deserialize( final File file, final Model model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException
+			{
+				try (final ObjectInputStream ois = new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+				{
+					final PoolCollectionWrapper< Spot > spots = model.getGraph().vertices();
+					final DoublePropertyMap< Spot > pm = new DoublePropertyMap<>( spots, Double.NaN, spots.size() );
+					final DoublePropertyMapSerializer< Spot > serializer = new DoublePropertyMapSerializer<>( pm );
+					@SuppressWarnings( "unchecked" )
+					final FileIdToObjectMap< Spot > idToLinkMap = ( FileIdToObjectMap< Spot > ) fileIdToGraphMap.vertices();
+					serializer.readPropertyMap( idToLinkMap, ois );
+					return MamutFeatureSerializers.bundle( key, pm, Spot.class );
+				}
+				catch ( final ClassNotFoundException e )
+				{
+					e.printStackTrace();
+				}
+				return null;
+			}
+		};
+	}
+
 
 	public static final < O > Feature< O, DoublePropertyMap< O > > bundle( final String featureKey, final DoublePropertyMap< O > propertyMap, final Class< O > clazz )
 	{
@@ -92,196 +235,6 @@ public class MamutFeatureSerializers
 		return feature;
 	}
 
-//
-//	/*
-//	 * INNER CLASSES
-//	 */
-//
-//	private static final class DoubleSpotFeatureSerializer implements FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model >
-//	{
-//
-//		private final String featureKey;
-//
-//		public DoubleSpotFeatureSerializer( final String featureKey )
-//		{
-//			this.featureKey = featureKey;
-//		}
-//
-//		@Override
-//		public void serialize( final Feature< Spot, DoublePropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
-//		{
-//			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
-//		}
-//
-//		@Override
-//		public Feature< Spot, DoublePropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
-//		{
-//			final DoublePropertyMap< Spot > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().vertices().getRefPool(), Double.NaN );
-//			return bundle( featureKey, propertyMap, Spot.class );
-//		}
-//	}
-//
-//	private static final class DoubleLinkFeatureSerializer implements FeatureSerializer< Link, DoublePropertyMap< Link >, Model >
-//	{
-//
-//		private final String featureKey;
-//
-//		public DoubleLinkFeatureSerializer( final String featureKey )
-//		{
-//			this.featureKey = featureKey;
-//		}
-//
-//		@Override
-//		public void serialize( final Feature< Link, DoublePropertyMap< Link > > feature, final File file, final Model model ) throws IOException
-//		{
-//			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
-//		}
-//
-//		@Override
-//		public Feature< Link, DoublePropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
-//		{
-//			final DoublePropertyMap< Link > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().edges().getRefPool(), Double.NaN );
-//			return bundle( featureKey, propertyMap, Link.class );
-//		}
-//
-//	}
-//
-//	private static final class IntSpotFeatureSerializer implements FeatureSerializer< Spot, IntPropertyMap< Spot >, Model >
-//	{
-//
-//		private final String featureKey;
-//
-//		public IntSpotFeatureSerializer( final String featureKey )
-//		{
-//			this.featureKey = featureKey;
-//		}
-//
-//		@Override
-//		public void serialize( final Feature< Spot, IntPropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
-//		{
-//			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
-//		}
-//
-//		@Override
-//		public Feature< Spot, IntPropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
-//		{
-//			final IntPropertyMap< Spot > pm = deserializeIntPropertyMap( file, model.getGraph().vertices().getRefPool(), Integer.MIN_VALUE );
-//			return bundle( featureKey, pm, Spot.class );
-//		}
-//	}
-//
-//	private static final class IntLinkFeatureSerializer implements FeatureSerializer< Link, IntPropertyMap< Link >, Model >
-//	{
-//
-//		private final String featureKey;
-//
-//		public IntLinkFeatureSerializer( final String featureKey )
-//		{
-//			this.featureKey = featureKey;
-//		}
-//
-//		@Override
-//		public void serialize( final Feature< Link, IntPropertyMap< Link > > feature, final File file, final Model model ) throws IOException
-//		{
-//			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
-//		}
-//
-//		@Override
-//		public Feature< Link, IntPropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
-//		{
-//			final IntPropertyMap< Link > pm = deserializeIntPropertyMap( file, model.getGraph().edges().getRefPool(), Integer.MIN_VALUE );
-//			return bundle( featureKey, pm, Link.class );
-//		}
-//	}
-//
-//	private static final < O > void serializeIntPropertyMap( final File file, final IntPropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
-//	{
-//		try (final ObjectOutputStream oos =
-//				new ObjectOutputStream(
-//						new BufferedOutputStream(
-//								new FileOutputStream( file ), 1024 * 1024 ) ))
-//		{
-//			final TIntIntHashMap fmap = new TIntIntHashMap();
-//			final RefIntMap< O > pmap = propertyMap.getMap();
-//			pmap.forEachEntry( ( final O key, final int value ) -> {
-//				fmap.put( pool.getId( key ), value );
-//				return true;
-//			} );
-//			oos.writeObject( fmap );
-//		}
-//	}
-//
-//	private static final < O > void serializeDoublePropertyMap( final File file, final DoublePropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
-//	{
-//		try (final ObjectOutputStream oos =
-//				new ObjectOutputStream(
-//						new BufferedOutputStream(
-//								new FileOutputStream( file ), 1024 * 1024 ) ))
-//		{
-//			final TIntDoubleHashMap fmap = new TIntDoubleHashMap();
-//			final RefDoubleMap< O > pmap = propertyMap.getMap();
-//			pmap.forEachEntry( ( final O key, final double value ) -> {
-//				fmap.put( pool.getId( key ), value );
-//				return true;
-//			} );
-//			oos.writeObject( fmap );
-//		}
-//	}
-//
-//	private static final < O > IntPropertyMap< O > deserializeIntPropertyMap( final File file, final RefPool< O > pool, final int noEntry ) throws IOException
-//	{
-//		try (final ObjectInputStream ois =
-//				new ObjectInputStream(
-//						new BufferedInputStream(
-//								new FileInputStream( file ), 1024 * 1024 ) ))
-//		{
-//			final TIntIntHashMap fmap = ( TIntIntHashMap ) ois.readObject();
-//			final IntPropertyMap< O > pm = new IntPropertyMap<>( pool, noEntry );
-//			final RefIntMap< O > pmap = pm.getMap();
-//			pmap.clear();
-//			final O ref = pool.createRef();
-//			fmap.forEachEntry( ( final int key, final int value ) -> {
-//				pmap.put( pool.getObject( key, ref ), value );
-//				return true;
-//			} );
-//			pool.releaseRef( ref );
-//			return pm;
-//		}
-//		catch ( final ClassNotFoundException e )
-//		{
-//			e.printStackTrace();
-//		}
-//		return null;
-//	}
-//
-//	private static final < O > DoublePropertyMap< O > deserializeDoublePropertyMap( final File file, final RefPool< O > pool, final double noEntry ) throws IOException
-//	{
-//		try (final ObjectInputStream ois =
-//				new ObjectInputStream(
-//						new BufferedInputStream(
-//								new FileInputStream( file ), 1024 * 1024 ) ))
-//		{
-//			final TIntDoubleHashMap fmap = ( TIntDoubleHashMap ) ois.readObject();
-//			final DoublePropertyMap< O > pm = new DoublePropertyMap<>( pool, noEntry );
-//			final RefDoubleMap< O > pmap = pm.getMap();
-//			pmap.clear();
-//			final O ref = pool.createRef();
-//			fmap.forEachEntry( ( final int key, final double value ) -> {
-//				pmap.put( pool.getObject( key, ref ), value );
-//				return true;
-//			} );
-//			pool.releaseRef( ref );
-//			return pm;
-//		}
-//		catch ( final ClassNotFoundException e )
-//		{
-//			e.printStackTrace();
-//		}
-//		return null;
-//	}
-
-
 	private MamutFeatureSerializers()
 	{}
-
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/MamutFeatureSerializers.java
@@ -1,0 +1,302 @@
+package org.mastodon.revised.mamut.feature;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.Map;
+
+import org.mastodon.RefPool;
+import org.mastodon.collection.RefDoubleMap;
+import org.mastodon.collection.RefIntMap;
+import org.mastodon.properties.DoublePropertyMap;
+import org.mastodon.properties.IntPropertyMap;
+import org.mastodon.revised.model.feature.Feature;
+import org.mastodon.revised.model.feature.FeatureProjection;
+import org.mastodon.revised.model.feature.FeatureProjectors;
+import org.mastodon.revised.model.feature.FeatureSerializer;
+import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.Spot;
+
+import gnu.trove.map.hash.TIntDoubleHashMap;
+import gnu.trove.map.hash.TIntIntHashMap;
+
+/**
+ * Utility {@link FeatureSerializer}s for MaMuT.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class MamutFeatureSerializers
+{
+
+	/**
+	 * Returns a serializer able to de/serialize a <code>double</code> feature
+	 * defined on {@link Link}.
+	 *
+	 * @param featureKey
+	 *            the feature key.
+	 * @return a new feature serializer.
+	 */
+	public static FeatureSerializer< Link, DoublePropertyMap< Link >, Model > doubleLinkSerializer( final String featureKey )
+	{
+		return new DoubleLinkFeatureSerializer( featureKey );
+	}
+
+	/**
+	 * Returns a serializer able to de/serialize a <code>double</code> feature
+	 * defined on {@link Spot}.
+	 *
+	 * @param featureKey
+	 *            the feature key.
+	 * @return a new feature serializer.
+	 */
+	public static FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model > doubleSpotSerializer( final String featureKey )
+	{
+		return new DoubleSpotFeatureSerializer( featureKey );
+	}
+
+	/**
+	 * Returns a serializer able to de/serialize a <code>in</code> feature
+	 * defined on {@link Spot}.
+	 *
+	 * @param featureKey
+	 *            the feature key.
+	 * @return a new feature serializer.
+	 */
+	public static FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > intSpotSerializer( final String featureKey )
+	{
+		return new IntSpotFeatureSerializer( featureKey );
+	}
+
+	/**
+	 * Returns a serializer able to de/serialize a <code>in</code> feature
+	 * defined on {@link Link}.
+	 *
+	 * @param featureKey
+	 *            the feature key.
+	 * @return a new feature serializer.
+	 */
+	public static FeatureSerializer< Link, IntPropertyMap< Link >, Model > intLinkSerializer( final String featureKey )
+	{
+		return new IntLinkFeatureSerializer( featureKey );
+	}
+
+	public static final < O > Feature< O, DoublePropertyMap< O > > bundle( final String featureKey, final DoublePropertyMap< O > propertyMap, final Class< O > clazz )
+	{
+		final Map< String, FeatureProjection< O > > projections = Collections.singletonMap( featureKey, FeatureProjectors.project( propertyMap ) );
+		final Feature< O, DoublePropertyMap< O > > feature = new Feature<>(
+				featureKey,
+				clazz,
+				propertyMap,
+				projections );
+		return feature;
+	}
+
+	public static final < O > Feature< O, IntPropertyMap< O > > bundle( final String featureKey, final IntPropertyMap< O > propertyMap, final Class< O > clazz )
+	{
+		final Map< String, FeatureProjection< O > > projections = Collections.singletonMap( featureKey, FeatureProjectors.project( propertyMap ) );
+		final Feature< O, IntPropertyMap< O > > feature = new Feature<>(
+				featureKey,
+				clazz,
+				propertyMap,
+				projections );
+		return feature;
+	}
+
+	/*
+	 * INNER CLASSES
+	 */
+
+	private static final class DoubleSpotFeatureSerializer implements FeatureSerializer< Spot, DoublePropertyMap< Spot >, Model >
+	{
+
+		private final String featureKey;
+
+		public DoubleSpotFeatureSerializer( final String featureKey )
+		{
+			this.featureKey = featureKey;
+		}
+
+		@Override
+		public void serialize( final Feature< Spot, DoublePropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
+		{
+			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
+		}
+
+		@Override
+		public Feature< Spot, DoublePropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
+		{
+			final DoublePropertyMap< Spot > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().vertices().getRefPool(), Double.NaN );
+			return bundle( featureKey, propertyMap, Spot.class );
+		}
+	}
+
+	private static final class DoubleLinkFeatureSerializer implements FeatureSerializer< Link, DoublePropertyMap< Link >, Model >
+	{
+
+		private final String featureKey;
+
+		public DoubleLinkFeatureSerializer( final String featureKey )
+		{
+			this.featureKey = featureKey;
+		}
+
+		@Override
+		public void serialize( final Feature< Link, DoublePropertyMap< Link > > feature, final File file, final Model model ) throws IOException
+		{
+			serializeDoublePropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
+		}
+
+		@Override
+		public Feature< Link, DoublePropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
+		{
+			final DoublePropertyMap< Link > propertyMap = deserializeDoublePropertyMap( file, model.getGraph().edges().getRefPool(), Double.NaN );
+			return bundle( featureKey, propertyMap, Link.class );
+		}
+
+	}
+
+	private static final class IntSpotFeatureSerializer implements FeatureSerializer< Spot, IntPropertyMap< Spot >, Model >
+	{
+
+		private final String featureKey;
+
+		public IntSpotFeatureSerializer( final String featureKey )
+		{
+			this.featureKey = featureKey;
+		}
+
+		@Override
+		public void serialize( final Feature< Spot, IntPropertyMap< Spot > > feature, final File file, final Model model ) throws IOException
+		{
+			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().vertices().getRefPool() );
+		}
+
+		@Override
+		public Feature< Spot, IntPropertyMap< Spot > > deserialize( final File file, final Model model ) throws IOException
+		{
+			final IntPropertyMap< Spot > pm = deserializeIntPropertyMap( file, model.getGraph().vertices().getRefPool(), Integer.MIN_VALUE );
+			return bundle( featureKey, pm, Spot.class );
+		}
+	}
+
+	private static final class IntLinkFeatureSerializer implements FeatureSerializer< Link, IntPropertyMap< Link >, Model >
+	{
+
+		private final String featureKey;
+
+		public IntLinkFeatureSerializer( final String featureKey )
+		{
+			this.featureKey = featureKey;
+		}
+
+		@Override
+		public void serialize( final Feature< Link, IntPropertyMap< Link > > feature, final File file, final Model model ) throws IOException
+		{
+			serializeIntPropertyMap( file, feature.getPropertyMap(), model.getGraph().edges().getRefPool() );
+		}
+
+		@Override
+		public Feature< Link, IntPropertyMap< Link > > deserialize( final File file, final Model model ) throws IOException
+		{
+			final IntPropertyMap< Link > pm = deserializeIntPropertyMap( file, model.getGraph().edges().getRefPool(), Integer.MIN_VALUE );
+			return bundle( featureKey, pm, Link.class );
+		}
+	}
+
+	private static final < O > void serializeIntPropertyMap( final File file, final IntPropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
+	{
+		try (final ObjectOutputStream oos =
+				new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+		{
+			final TIntIntHashMap fmap = new TIntIntHashMap();
+			final RefIntMap< O > pmap = propertyMap.getMap();
+			pmap.forEachEntry( ( final O key, final int value ) -> {
+				fmap.put( pool.getId( key ), value );
+				return true;
+			} );
+			oos.writeObject( fmap );
+		}
+	}
+
+	private static final < O > void serializeDoublePropertyMap( final File file, final DoublePropertyMap< O > propertyMap, final RefPool< O > pool ) throws IOException
+	{
+		try (final ObjectOutputStream oos =
+				new ObjectOutputStream(
+						new BufferedOutputStream(
+								new FileOutputStream( file ), 1024 * 1024 ) ))
+		{
+			final TIntDoubleHashMap fmap = new TIntDoubleHashMap();
+			final RefDoubleMap< O > pmap = propertyMap.getMap();
+			pmap.forEachEntry( ( final O key, final double value ) -> {
+				fmap.put( pool.getId( key ), value );
+				return true;
+			} );
+			oos.writeObject( fmap );
+		}
+	}
+
+	private static final < O > IntPropertyMap< O > deserializeIntPropertyMap( final File file, final RefPool< O > pool, final int noEntry ) throws IOException
+	{
+		try (final ObjectInputStream ois =
+				new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+		{
+			final TIntIntHashMap fmap = ( TIntIntHashMap ) ois.readObject();
+			final IntPropertyMap< O > pm = new IntPropertyMap<>( pool, noEntry );
+			final RefIntMap< O > pmap = pm.getMap();
+			pmap.clear();
+			final O ref = pool.createRef();
+			fmap.forEachEntry( ( final int key, final int value ) -> {
+				pmap.put( pool.getObject( key, ref ), value );
+				return true;
+			} );
+			pool.releaseRef( ref );
+			return pm;
+		}
+		catch ( final ClassNotFoundException e )
+		{
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private static final < O > DoublePropertyMap< O > deserializeDoublePropertyMap( final File file, final RefPool< O > pool, final double noEntry ) throws IOException
+	{
+		try (final ObjectInputStream ois =
+				new ObjectInputStream(
+						new BufferedInputStream(
+								new FileInputStream( file ), 1024 * 1024 ) ))
+		{
+			final TIntDoubleHashMap fmap = ( TIntDoubleHashMap ) ois.readObject();
+			final DoublePropertyMap< O > pm = new DoublePropertyMap<>( pool, noEntry );
+			final RefDoubleMap< O > pmap = pm.getMap();
+			pmap.clear();
+			final O ref = pool.createRef();
+			fmap.forEachEntry( ( final int key, final double value ) -> {
+				pmap.put( pool.getObject( key, ref ), value );
+				return true;
+			} );
+			pool.releaseRef( ref );
+			return pm;
+		}
+		catch ( final ClassNotFoundException e )
+		{
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private MamutFeatureSerializers()
+	{}
+
+}

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotFeatureComputer.java
@@ -1,7 +1,9 @@
 package org.mastodon.revised.mamut.feature;
 
+import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.feature.FeatureComputer;
 import org.mastodon.revised.model.mamut.Model;
+import org.mastodon.revised.model.mamut.Spot;
 
 /**
  * Marker interface for MaMuT feature computers to sort between different
@@ -9,5 +11,5 @@ import org.mastodon.revised.model.mamut.Model;
  *
  * @author Jean-Yves Tinevez
  */
-public interface SpotFeatureComputer extends FeatureComputer< Model >
+public interface SpotFeatureComputer< M extends PropertyMap< Spot, ? > > extends FeatureComputer< Spot, M, Model >
 {}

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotNLinksComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotNLinksComputer.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.io.properties.IntPropertyMapSerializer;
 import org.mastodon.pool.PoolCollectionWrapper;
 import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -41,7 +42,12 @@ public class SpotNLinksComputer implements SpotFeatureComputer
 			pm.set( spot, spot.edges().size() );
 
 		final Map< String, FeatureProjection< Spot > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( pm ) );
-		final Feature< Spot, IntPropertyMap< Spot > > feature = new Feature<>( KEY, Spot.class, pm, projections );
+		final Feature< Spot, IntPropertyMap< Spot > > feature = new Feature<>(
+				KEY,
+				Spot.class,
+				pm,
+				projections,
+				new IntPropertyMapSerializer<>( pm ));
 		return feature;
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotNLinksComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotNLinksComputer.java
@@ -1,24 +1,18 @@
 package org.mastodon.revised.mamut.feature;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.FileIdToObjectMap;
-import org.mastodon.io.properties.IntPropertyMapSerializer;
 import org.mastodon.pool.PoolCollectionWrapper;
 import org.mastodon.properties.IntPropertyMap;
 import org.mastodon.revised.model.feature.Feature;
-import org.mastodon.revised.model.feature.FeatureProjection;
-import org.mastodon.revised.model.feature.FeatureProjectors;
+import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
 
 @Plugin( type = SpotFeatureComputer.class, name = "Spot N links" )
-public class SpotNLinksComputer implements SpotFeatureComputer
+public class SpotNLinksComputer implements SpotFeatureComputer< IntPropertyMap< Spot > >
 {
 
 	private static final String KEY = "Spot N links";
@@ -44,36 +38,12 @@ public class SpotNLinksComputer implements SpotFeatureComputer
 		for ( final Spot spot : vertices )
 			pm.set( spot, spot.edges().size() );
 
-		return bundle( pm );
+		return MamutFeatureSerializers.bundle( KEY, pm, Spot.class );
 	}
 
 	@Override
-	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
+	public FeatureSerializer< Spot, IntPropertyMap< Spot >, Model > getSerializer()
 	{
-		final IntPropertyMap< Spot > pm = new IntPropertyMap<>( model.getGraph().vertices(), -1 );
-		final IntPropertyMapSerializer< Spot > serializer = new IntPropertyMapSerializer<>( pm );
-		@SuppressWarnings( "unchecked" )
-		final FileIdToObjectMap< Spot > idmap = ( FileIdToObjectMap< Spot > ) fileIdToObjectMap;
-		try
-		{
-			serializer.readPropertyMap( idmap, ois );
-		}
-		catch ( ClassNotFoundException | IOException e1 )
-		{
-			e1.printStackTrace();
-		}
-		return bundle( pm );
-	}
-
-	private Feature< Spot, IntPropertyMap< Spot> > bundle( final IntPropertyMap< Spot > propertyMap )
-	{
-		final Map< String, FeatureProjection< Spot > > projections = Collections.singletonMap( KEY, FeatureProjectors.project( propertyMap ) );
-		final Feature< Spot, IntPropertyMap< Spot > > feature = new Feature<>(
-				KEY,
-				Spot.class,
-				propertyMap,
-				projections,
-				new IntPropertyMapSerializer<>( propertyMap ) );
-		return feature;
+		return MamutFeatureSerializers.intSpotSerializer(KEY);
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
@@ -1,10 +1,16 @@
 package org.mastodon.revised.mamut.feature;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.AbstractPropertyMap;
 import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -44,11 +50,14 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 			map.put( pname, projection );
 		}
 		final Map< String, FeatureProjection< Spot > > projections = Collections.unmodifiableMap( map );
+		final RealLocalizablePropertyMap< Spot > rlpm = new RealLocalizablePropertyMap< Spot >( model.getGraph().vertices().size() );
+		final PropertyMapSerializer< Spot, PropertyMap< Spot, RealLocalizable > > pms = new DummyPropertyMapSerializer< Spot >();
 		final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature =
-				new Feature<>(
+				new Feature< Spot, PropertyMap< Spot, RealLocalizable > >(
 						KEY, Spot.class,
-						new RealLocalizablePropertyMap< Spot >( model.getGraph().vertices().size() ),
-						projections );
+						rlpm,
+						projections,
+						pms );
 		return feature;
 	}
 
@@ -135,5 +144,28 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 			return size;
 		}
 
+	}
+
+	private static class DummyPropertyMapSerializer< O > implements PropertyMapSerializer< O, PropertyMap< O, RealLocalizable > >
+	{
+
+		@Override
+		public void writePropertyMap( final ObjectToFileIdMap< O > idmap, final ObjectOutputStream oos ) throws IOException
+		{
+			// Do nothing.
+		}
+
+		@Override
+		public void readPropertyMap( final FileIdToObjectMap< O > idmap, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
+		{
+			// Do nothing.
+		}
+
+		@Override
+		public PropertyMap< O, RealLocalizable > getPropertyMap()
+		{
+			// Return nothing.
+			return null;
+		}
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.properties.AbstractPropertyMap;
 import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.feature.Feature;
@@ -47,9 +49,9 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer< Propert
 			map.put( pname, projection );
 		}
 		final Map< String, FeatureProjection< Spot > > projections = Collections.unmodifiableMap( map );
-		final RealLocalizablePropertyMap< Spot > rlpm = new RealLocalizablePropertyMap< Spot >( model.getGraph().vertices().size() );
+		final RealLocalizablePropertyMap< Spot > rlpm = new RealLocalizablePropertyMap< >( model.getGraph().vertices().size() );
 		final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature =
-				new Feature< Spot, PropertyMap< Spot, RealLocalizable > >(
+				new Feature< >(
 						KEY, Spot.class,
 						rlpm,
 						projections );
@@ -148,13 +150,13 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer< Propert
 		{
 
 			@Override
-			public void serialize( final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature, final File file, final Model model ) throws IOException
+			public void serialize( final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature, final File file, final Model support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException
 			{
 				// Do nothing.
 			}
 
 			@Override
-			public Feature< Spot, PropertyMap< Spot, RealLocalizable > > deserialize( final File file, final Model model ) throws IOException
+			public Feature< Spot, PropertyMap< Spot, RealLocalizable > > deserialize( final File file, final Model model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException
 			{
 				// Do nothing and return the feature as is.
 				return compute( model );

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
@@ -61,6 +61,13 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 		return feature;
 	}
 
+	@Override
+	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
+	{
+		// Do nothing but return the feature.
+		return compute( model );
+	}
+
 	private final static class SpotPositionProjection implements FeatureProjection< Spot >
 	{
 

--- a/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/mamut/feature/SpotPositionFeatureComputer.java
@@ -1,20 +1,17 @@
 package org.mastodon.revised.mamut.feature;
 
+import java.io.File;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.FileIdToObjectMap;
-import org.mastodon.io.ObjectToFileIdMap;
-import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.AbstractPropertyMap;
 import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.feature.Feature;
 import org.mastodon.revised.model.feature.FeatureProjection;
+import org.mastodon.revised.model.feature.FeatureSerializer;
 import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.Spot;
 import org.scijava.plugin.Plugin;
@@ -22,7 +19,7 @@ import org.scijava.plugin.Plugin;
 import net.imglib2.RealLocalizable;
 
 @Plugin( type = SpotFeatureComputer.class, name = "Spot position" )
-public class SpotPositionFeatureComputer implements SpotFeatureComputer
+public class SpotPositionFeatureComputer implements SpotFeatureComputer< PropertyMap< Spot, RealLocalizable > >
 {
 
 	private static final String KEY = "Spot position";
@@ -42,7 +39,7 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 	@Override
 	public Feature< Spot, PropertyMap< Spot, RealLocalizable > > compute( final Model model )
 	{
-		final HashMap< String, FeatureProjection< Spot > > map = new HashMap<>();
+		final LinkedHashMap< String, FeatureProjection< Spot > > map = new LinkedHashMap<>();
 		for ( int d = 0; d < 3; d++ )
 		{
 			final String pname = "Spot " + ( char ) ( 'X' + d ) + " position";
@@ -51,21 +48,12 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 		}
 		final Map< String, FeatureProjection< Spot > > projections = Collections.unmodifiableMap( map );
 		final RealLocalizablePropertyMap< Spot > rlpm = new RealLocalizablePropertyMap< Spot >( model.getGraph().vertices().size() );
-		final PropertyMapSerializer< Spot, PropertyMap< Spot, RealLocalizable > > pms = new DummyPropertyMapSerializer< Spot >();
 		final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature =
 				new Feature< Spot, PropertyMap< Spot, RealLocalizable > >(
 						KEY, Spot.class,
 						rlpm,
-						projections,
-						pms );
+						projections );
 		return feature;
-	}
-
-	@Override
-	public Feature< ?, ? > deserialize( final ObjectInputStream ois, final FileIdToObjectMap< ? > fileIdToObjectMap, final Model model )
-	{
-		// Do nothing but return the feature.
-		return compute( model );
 	}
 
 	private final static class SpotPositionProjection implements FeatureProjection< Spot >
@@ -153,26 +141,24 @@ public class SpotPositionFeatureComputer implements SpotFeatureComputer
 
 	}
 
-	private static class DummyPropertyMapSerializer< O > implements PropertyMapSerializer< O, PropertyMap< O, RealLocalizable > >
+	@Override
+	public FeatureSerializer< Spot, PropertyMap< Spot, RealLocalizable >, Model > getSerializer()
 	{
-
-		@Override
-		public void writePropertyMap( final ObjectToFileIdMap< O > idmap, final ObjectOutputStream oos ) throws IOException
+		return new FeatureSerializer< Spot, PropertyMap< Spot, RealLocalizable >, Model >()
 		{
-			// Do nothing.
-		}
 
-		@Override
-		public void readPropertyMap( final FileIdToObjectMap< O > idmap, final ObjectInputStream ois ) throws IOException, ClassNotFoundException
-		{
-			// Do nothing.
-		}
+			@Override
+			public void serialize( final Feature< Spot, PropertyMap< Spot, RealLocalizable > > feature, final File file, final Model model ) throws IOException
+			{
+				// Do nothing.
+			}
 
-		@Override
-		public PropertyMap< O, RealLocalizable > getPropertyMap()
-		{
-			// Return nothing.
-			return null;
-		}
+			@Override
+			public Feature< Spot, PropertyMap< Spot, RealLocalizable > > deserialize( final File file, final Model model ) throws IOException
+			{
+				// Do nothing and return the feature as is.
+				return compute( model );
+			}
+		};
 	}
 }

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -84,6 +84,15 @@ public class AbstractModelGraph<
 	{
 		final FileInputStream fis = new FileInputStream( file );
 		final ObjectInputStream ois = new ObjectInputStream( new BufferedInputStream( fis, 1024 * 1024 ) );
+		readRaw( ois, serializer );
+		ois.close();
+	}
+
+	public FileIdToGraphMap< V, E > readRaw(
+			final ObjectInputStream ois,
+			final GraphSerializer< V, E > serializer )
+					throws IOException
+	{
 		pauseListeners();
 		clear();
 		final FileIdToGraphMap< V, E > fileIdMap = RawGraphIO.read( this, idmap, serializer, ois );
@@ -91,9 +100,10 @@ public class AbstractModelGraph<
 		// TODO: edge properties
 //		RawFeatureIO.readFeatureMaps( fileIdMap.vertices(), vertexFeatures, ois );
 //		RawFeatureIO.readFeatureMaps( fileIdMap.edges(), edgeFeatures, ois );
-		ois.close();
 		resumeListeners();
+		return fileIdMap;
 	}
+
 
 	/**
 	 * Saves this model-graph to the specified raw file using the specified

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -82,31 +82,23 @@ public class AbstractModelGraph<
 	public FileIdToGraphMap< V, E > loadRaw(
 			final File file,
 			final GraphSerializer< V, E > serializer )
-					throws IOException
+			throws IOException
 	{
-		final FileInputStream fis = new FileInputStream( file );
-		final ObjectInputStream ois = new ObjectInputStream( new BufferedInputStream( fis, 1024 * 1024 ) );
-		final FileIdToGraphMap< V, E > fileIdToGraphMap = readRaw( ois, serializer );
-		ois.close();
-		return fileIdToGraphMap;
-	}
-
-	public FileIdToGraphMap< V, E > readRaw(
-			final ObjectInputStream ois,
-			final GraphSerializer< V, E > serializer )
-					throws IOException
-	{
-		pauseListeners();
-		clear();
-		final FileIdToGraphMap< V, E > fileIdMap = RawGraphIO.read( this, idmap, serializer, ois );
-		RawPropertyIO.readPropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, ois );
-		// TODO: edge properties
+		try (final ObjectInputStream ois = new ObjectInputStream(
+				new BufferedInputStream(
+						new FileInputStream( file ), 1024 * 1024 ) );)
+		{
+			pauseListeners();
+			clear();
+			final FileIdToGraphMap< V, E > fileIdMap = RawGraphIO.read( this, idmap, serializer, ois );
+			RawPropertyIO.readPropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, ois );
+			// TODO: edge properties
 //		RawFeatureIO.readFeatureMaps( fileIdMap.vertices(), vertexFeatures, ois );
 //		RawFeatureIO.readFeatureMaps( fileIdMap.edges(), edgeFeatures, ois );
-		resumeListeners();
-		return fileIdMap;
+			resumeListeners();
+			return fileIdMap;
+		}
 	}
-
 
 	/**
 	 * Saves this model-graph to the specified raw file using the specified
@@ -123,17 +115,19 @@ public class AbstractModelGraph<
 	public GraphToFileIdMap< V, E > saveRaw(
 			final File file,
 			final GraphSerializer< V, E > serializer )
-					throws IOException
+			throws IOException
 	{
-		final FileOutputStream fos = new FileOutputStream( file );
-		final ObjectOutputStream oos = new ObjectOutputStream( new BufferedOutputStream( fos, 1024 * 1024 ) );
-		final GraphToFileIdMap< V, E > fileIdMap = RawGraphIO.write( this, idmap, serializer, oos );
-		RawPropertyIO.writePropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, oos );
-		// TODO: edge properties
+		try (final ObjectOutputStream oos = new ObjectOutputStream(
+				new BufferedOutputStream(
+						new FileOutputStream( file ), 1024 * 1024 ) ))
+		{
+			final GraphToFileIdMap< V, E > fileIdMap = RawGraphIO.write( this, idmap, serializer, oos );
+			RawPropertyIO.writePropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, oos );
+			// TODO: edge properties
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.vertices(), vertexFeatures, vertexFeaturesToSerialize, oos );
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.edges(), edgeFeatures, edgeFeaturesToSerialize, oos );
-		oos.close();
-		return fileIdMap;
+			return fileIdMap;
+		}
 	}
 
 	public ReentrantReadWriteLock getLock()

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -74,18 +74,21 @@ public class AbstractModelGraph<
 	 *            the raw file to load.
 	 * @param serializer
 	 *            the serializer used for reading individual vertices.
+	 * @return the map collection that links file object ids to graph object
+	 *         ids.
 	 * @throws IOException
 	 *             if an I/O error occurs while reading the file.
 	 */
-	public void loadRaw(
+	public FileIdToGraphMap< V, E > loadRaw(
 			final File file,
 			final GraphSerializer< V, E > serializer )
 					throws IOException
 	{
 		final FileInputStream fis = new FileInputStream( file );
 		final ObjectInputStream ois = new ObjectInputStream( new BufferedInputStream( fis, 1024 * 1024 ) );
-		readRaw( ois, serializer );
+		final FileIdToGraphMap< V, E > fileIdToGraphMap = readRaw( ois, serializer );
 		ois.close();
+		return fileIdToGraphMap;
 	}
 
 	public FileIdToGraphMap< V, E > readRaw(

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -127,31 +127,12 @@ public class AbstractModelGraph<
 	{
 		final FileOutputStream fos = new FileOutputStream( file );
 		final ObjectOutputStream oos = new ObjectOutputStream( new BufferedOutputStream( fos, 1024 * 1024 ) );
-		writeRaw( oos, serializer );
-		oos.close();
-	}
-
-	/**
-	 * Appends this model-graph to the specified stream using the specified
-	 * serializer.
-	 *
-	 * @param oos
-	 *            The stream to append the graph to. Will not be closed.
-	 * @param serializer
-	 *            The serializer to use to write the model graph.
-	 * @return A mapping from graph objects to file ids.
-	 */
-	public GraphToFileIdMap< V, E > writeRaw(
-			final ObjectOutputStream oos,
-			final GraphSerializer< V, E > serializer )
-			throws IOException
-	{
 		final GraphToFileIdMap< V, E > fileIdMap = RawGraphIO.write( this, idmap, serializer, oos );
 		RawPropertyIO.writePropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, oos );
 		// TODO: edge properties
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.vertices(), vertexFeatures, vertexFeaturesToSerialize, oos );
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.edges(), edgeFeatures, edgeFeaturesToSerialize, oos );
-		return fileIdMap;
+		oos.close();
 	}
 
 	public ReentrantReadWriteLock getLock()

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -116,14 +116,11 @@ public class AbstractModelGraph<
 	 *            the raw file to save.
 	 * @param serializer
 	 *            the serializer used for writing individual vertices.
-//	 * @param vertexFeaturesToSerialize
-//	 *            the vertex features to serialize.
-//	 * @param edgeFeaturesToSerialize
-//	 *            the edge features to serialize.
+	 * @return the map collection that links graph object id to file object id.
 	 * @throws IOException
 	 *             if an I/O error occurs while writing the file.
 	 */
-	public void saveRaw(
+	public GraphToFileIdMap< V, E > saveRaw(
 			final File file,
 			final GraphSerializer< V, E > serializer )
 					throws IOException
@@ -136,6 +133,7 @@ public class AbstractModelGraph<
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.vertices(), vertexFeatures, vertexFeaturesToSerialize, oos );
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.edges(), edgeFeatures, edgeFeaturesToSerialize, oos );
 		oos.close();
+		return fileIdMap;
 	}
 
 	public ReentrantReadWriteLock getLock()

--- a/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
+++ b/src/main/java/org/mastodon/revised/model/AbstractModelGraph.java
@@ -96,7 +96,7 @@ public class AbstractModelGraph<
 	}
 
 	/**
-	 * Saves this model to the specified raw file using the specified
+	 * Saves this model-graph to the specified raw file using the specified
 	 * serializer.
 	 *
 	 * @param file
@@ -117,12 +117,31 @@ public class AbstractModelGraph<
 	{
 		final FileOutputStream fos = new FileOutputStream( file );
 		final ObjectOutputStream oos = new ObjectOutputStream( new BufferedOutputStream( fos, 1024 * 1024 ) );
+		writeRaw( oos, serializer );
+		oos.close();
+	}
+
+	/**
+	 * Appends this model-graph to the specified stream using the specified
+	 * serializer.
+	 *
+	 * @param oos
+	 *            The stream to append the graph to. Will not be closed.
+	 * @param serializer
+	 *            The serializer to use to write the model graph.
+	 * @return A mapping from graph objects to file ids.
+	 */
+	public GraphToFileIdMap< V, E > writeRaw(
+			final ObjectOutputStream oos,
+			final GraphSerializer< V, E > serializer )
+			throws IOException
+	{
 		final GraphToFileIdMap< V, E > fileIdMap = RawGraphIO.write( this, idmap, serializer, oos );
 		RawPropertyIO.writePropertyMaps( fileIdMap.vertices(), vertexPropertySerializers, oos );
 		// TODO: edge properties
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.vertices(), vertexFeatures, vertexFeaturesToSerialize, oos );
 //		RawFeatureIO.writeFeatureMaps( fileIdMap.edges(), edgeFeatures, edgeFeaturesToSerialize, oos );
-		oos.close();
+		return fileIdMap;
 	}
 
 	public ReentrantReadWriteLock getLock()

--- a/src/main/java/org/mastodon/revised/model/feature/AbstractFeatureComputerService.java
+++ b/src/main/java/org/mastodon/revised/model/feature/AbstractFeatureComputerService.java
@@ -39,13 +39,13 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	 * Feature computers of any type, mapped by their key, for dependency
 	 * management.
 	 */
-	private final Map< String, FeatureComputer< AM > > featureComputers = new HashMap<>();
+	private final Map< String, FeatureComputer< ?, ?, AM > > featureComputers = new HashMap<>();
 
 	@Override
-	public boolean compute( final AM model, final FeatureModel featureModel, final Set< FeatureComputer< AM > > computers, final ProgressListener progressListener )
+	public boolean compute( final AM model, final FeatureModel< AM > featureModel, final Set< FeatureComputer< ?, ?, AM > > computers, final ProgressListener progressListener )
 	{
-		final ObjectGraph< FeatureComputer< AM > > dependencyGraph = getDependencyGraph( computers );
-		final TopologicalSort< ObjectVertex< FeatureComputer< AM > >, ObjectEdge< FeatureComputer< AM > > > sorter = new TopologicalSort<>( dependencyGraph );
+		final ObjectGraph< FeatureComputer< ?, ?, AM > > dependencyGraph = getDependencyGraph( computers );
+		final TopologicalSort< ObjectVertex< FeatureComputer< ?, ?, AM > >, ObjectEdge< FeatureComputer< ?, ?, AM > > > sorter = new TopologicalSort<>( dependencyGraph );
 
 		if ( sorter.hasFailed() )
 		{
@@ -59,9 +59,9 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 
 		featureModel.clear();
 		int progress = 1;
-		for ( final ObjectVertex< FeatureComputer< AM > > v : sorter.get() )
+		for ( final ObjectVertex< FeatureComputer< ?, ?, AM > > v : sorter.get() )
 		{
-			final FeatureComputer< AM > computer = v.getContent();
+			final FeatureComputer< ?, ?, AM > computer = v.getContent();
 			progressListener.showStatus( computer.getKey() );
 			final Feature< ?, ? > feature = computer.compute( model );
 			featureModel.declareFeature( feature );
@@ -80,13 +80,13 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	 * DEPENDENCY GRAPH.
 	 */
 
-	private ObjectGraph< FeatureComputer< AM > > getDependencyGraph( final Set< FeatureComputer< AM > > computers )
+	private ObjectGraph< FeatureComputer< ?, ?, AM > > getDependencyGraph( final Set< FeatureComputer< ?, ?, AM > > computers )
 	{
-		final ObjectGraph< FeatureComputer< AM > > computerGraph = new ObjectGraph<>();
-		final ObjectVertex< FeatureComputer< AM > > ref = computerGraph.vertexRef();
+		final ObjectGraph< FeatureComputer< ?, ?, AM > > computerGraph = new ObjectGraph<>();
+		final ObjectVertex< FeatureComputer< ?, ?, AM > > ref = computerGraph.vertexRef();
 
-		final Set< FeatureComputer< AM > > requestedFeatureComputers = new HashSet<>();
-		for ( final FeatureComputer< AM > computer : computers )
+		final Set< FeatureComputer< ?, ?, AM > > requestedFeatureComputers = new HashSet<>();
+		for ( final FeatureComputer< ?, ?, AM > computer : computers )
 		{
 			// Build a list of feature computers.
 			requestedFeatureComputers.add( computer );
@@ -111,9 +111,9 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	 * @param computerGraph
 	 * @param requestedFeatureComputers
 	 */
-	private void prune( final ObjectGraph< FeatureComputer< AM > > computerGraph, final Set< FeatureComputer< AM > > requestedFeatureComputers )
+	private void prune( final ObjectGraph< FeatureComputer< ?, ?, AM > > computerGraph, final Set< FeatureComputer< ?, ?, AM > > requestedFeatureComputers )
 	{
-		for ( final ObjectVertex< FeatureComputer< AM > > v : new ArrayList<>( computerGraph.vertices() ) )
+		for ( final ObjectVertex< FeatureComputer< ?, ?, AM > > v : new ArrayList<>( computerGraph.vertices() ) )
 			if ( v.incomingEdges().isEmpty() && !requestedFeatureComputers.contains( v.getContent() ) )
 				computerGraph.remove( v );
 	}
@@ -126,33 +126,33 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	 * @param ref
 	 * @return
 	 */
-	private final ObjectVertex< FeatureComputer< AM > > addDepVertex(
-			final FeatureComputer< AM > computer,
-			final ObjectGraph< FeatureComputer< AM > > computerGraph,
-			final ObjectVertex< FeatureComputer< AM > > ref )
+	private final ObjectVertex< FeatureComputer< ?, ?, AM > > addDepVertex(
+			final FeatureComputer< ?, ?, AM > computer,
+			final ObjectGraph< FeatureComputer< ?, ?, AM > > computerGraph,
+			final ObjectVertex< FeatureComputer< ?, ?, AM > > ref )
 	{
-		for ( final ObjectVertex< FeatureComputer< AM > > v : computerGraph.vertices() )
+		for ( final ObjectVertex< FeatureComputer< ?, ?, AM > > v : computerGraph.vertices() )
 		{
 			if ( v.getContent().equals( computer ) )
 				return v;
 		}
 
-		final ObjectVertex< FeatureComputer< AM > > source = computerGraph.addVertex( ref ).init( computer );
+		final ObjectVertex< FeatureComputer< ?, ?, AM > > source = computerGraph.addVertex( ref ).init( computer );
 		final Set< String > deps = computer.getDependencies();
 
-		final ObjectVertex< FeatureComputer< AM > > vref2 = computerGraph.vertexRef();
-		final ObjectEdge< FeatureComputer< AM > > eref = computerGraph.edgeRef();
+		final ObjectVertex< FeatureComputer< ?, ?, AM > > vref2 = computerGraph.vertexRef();
+		final ObjectEdge< FeatureComputer< ?, ?, AM > > eref = computerGraph.edgeRef();
 
 		for ( final String dep : deps )
 		{
-			final FeatureComputer< AM > computerDep = featureComputers.get( dep );
+			final FeatureComputer< ?, ?, AM > computerDep = featureComputers.get( dep );
 			if ( null == computerDep )
 			{
 				logService.error( "Cannot add feature computer named " + dep + " as it is not registered." );
 				return null;
 			}
 
-			final ObjectVertex< FeatureComputer< AM > > target = addDepVertex( computerDep, computerGraph, vref2 );
+			final ObjectVertex< FeatureComputer< ?, ?, AM > > target = addDepVertex( computerDep, computerGraph, vref2 );
 			if ( null == target )
 			{
 				logService.error( "Removing feature computer named " + computer + " as some of its dependencies could not be resolved." );
@@ -172,7 +172,7 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	 * PRIVATE METHODS.
 	 */
 
-	protected < K extends FeatureComputer< AM > > void initializeFeatureComputers( final Class< K > cl )
+	protected < K extends FeatureComputer< ?, ?, AM > > void initializeFeatureComputers( final Class< K > cl )
 	{
 		final List< PluginInfo< K > > infos = pluginService.getPluginsOfType( cl );
 		for ( final PluginInfo< K > info : infos )
@@ -200,7 +200,7 @@ public abstract class AbstractFeatureComputerService< AM extends AbstractModel< 
 	}
 
 	@Override
-	public Collection< FeatureComputer< AM > > getFeatureComputers()
+	public Collection< FeatureComputer< ?, ?, AM > > getFeatureComputers()
 	{
 		return Collections.unmodifiableCollection( featureComputers.values() );
 	}

--- a/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
 import org.mastodon.revised.model.AbstractModel;
 
 /**
@@ -109,7 +110,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 	}
 
 	@Override
-	public void loadRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model )
+	public void loadRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final FileIdToGraphMap< ?, ? > fileIdToGraphMap )
 	{
 		clear();
 		final File featureFolder = new File( baseFolder, FEATURE_FOLDER );
@@ -134,7 +135,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 			}
 			try
 			{
-				final Feature< ?, ? > feature = featureSerializer.deserialize( featureFile, model );
+				final Feature< ?, ? > feature = featureSerializer.deserialize( featureFile, fileIdToGraphMap );
 				declareFeature( feature );
 			}
 			catch ( final IOException e )

--- a/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
@@ -1,23 +1,20 @@
 package org.mastodon.revised.model.feature;
 
+import java.io.File;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.ObjectToFileIdMap;
-import org.mastodon.io.properties.PropertyMapSerializer;
-import org.mastodon.io.properties.PropertyMapSerializers;
-import org.mastodon.io.properties.RawPropertyIO;
+import org.mastodon.revised.model.AbstractModel;
 
 /**
  * Default feature model.
  *
  * @author Jean-Yves Tinevez
  */
-public class DefaultFeatureModel implements FeatureModel
+public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implements FeatureModel< AM >
 {
 
 	private final Map< Class< ? >, Set< Feature< ?, ? > > > targetClassToFeatures;
@@ -39,7 +36,7 @@ public class DefaultFeatureModel implements FeatureModel
 		// Features.
 		final Class< ? > clazz = feature.getTargetClass();
 		Set< Feature< ?, ? > > featureSet = targetClassToFeatures.get( clazz );
-		if (null == featureSet)
+		if ( null == featureSet )
 		{
 			featureSet = new HashSet<>();
 			targetClassToFeatures.put( clazz, featureSet );
@@ -69,44 +66,99 @@ public class DefaultFeatureModel implements FeatureModel
 		return keyToFeature.get( key );
 	}
 
-	@SuppressWarnings( { "unchecked", "rawtypes" } )
+	@SuppressWarnings( "unchecked" )
 	@Override
-	public void writeRaw( final ObjectOutputStream oos, final Map< Class< ? >, ObjectToFileIdMap< ? > > fileIdMaps ) throws IOException
+	public void saveRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model )
 	{
-		// Collect feature to write and order them by target class.
-		final Map<Class< ? >, PropertyMapSerializers< ? > > serializerMap = new HashMap<>();
+		final File featureFolder = new File( baseFolder, FEATURE_FOLDER );
+		if (!featureFolder.exists())
+		{
+			final boolean created = featureFolder.mkdirs();
+			if (!created)
+			{
+				System.err.println( "Could not create folder to save features in: " + featureFolder );
+				return;
+			}
+		}
+		if (!featureFolder.isDirectory())
+		{
+			System.err.println( "Target folder to save feature in is not a directory: " + featureFolder );
+			return;
+		}
+
 		for ( final String featureKey : keyToFeature.keySet() )
 		{
-			final Feature< ?, ? > feature = keyToFeature.get( featureKey );
-			final Class< ? > targetClass = feature.getTargetClass();
-
-			PropertyMapSerializers< ? > propertyMapSerializers = serializerMap.get( targetClass );
-			if ( null == propertyMapSerializers )
+			final FeatureSerializer< ?, ?, AM > featureSerializer = serializers.get( featureKey );
+			if ( null == featureSerializer )
 			{
-				propertyMapSerializers = new PropertyMapSerializers<>();
-				serializerMap.put( targetClass, propertyMapSerializers );
-			}
-
-			final PropertyMapSerializer serializer = feature.getSerializer();
-			propertyMapSerializers.put( featureKey, serializer );
-		}
-
-		// Write several blocks of features, one by target class.
-		// Order imposed by the key of fileIdMaps.
-		for ( final Class< ? > targetClass : fileIdMaps.keySet() )
-		{
-			final PropertyMapSerializers serializers = serializerMap.get( targetClass );
-			if ( null == serializers )
-				continue;
-
-			final ObjectToFileIdMap idmap = fileIdMaps.get( targetClass );
-			if (null == idmap)
-			{
-				System.err.println( "Error while writing features. Do not have a file id map for target class " + targetClass );
+				System.err.println( "Cannot find a serializer to write feature " + featureKey + ". Skipped." );
 				continue;
 			}
-			RawPropertyIO.writePropertyMaps( idmap, serializers, oos );
+			final File featureFilePath = makeFeatureFilePath( baseFolder, featureKey );
+			try
+			{
+				@SuppressWarnings( "rawtypes" )
+				final Feature feature = keyToFeature.get( featureKey );
+				featureSerializer.serialize( feature, featureFilePath, model );
+			}
+			catch ( final IOException e )
+			{
+				System.err.println( "Could not serialize feature " + featureKey + " to file " + featureFilePath + ":\n" + e.getMessage() );
+			}
 		}
 	}
+
+	@Override
+	public void loadRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model )
+	{
+		clear();
+		final File featureFolder = new File( baseFolder, FEATURE_FOLDER );
+
+		final File[] featureFiles = featureFolder.listFiles( ( pathname ) -> pathname.getName().endsWith( RAW_EXTENSION ) );
+		if (null == featureFiles)
+			return;
+
+		for ( final File featureFile : featureFiles )
+		{
+			final String featureKey = getFeatureKeyFromFileName( featureFile );
+			if ( null == featureKey )
+			{
+				System.err.println( "Cannot retrieve feature key from file name " + featureFile + ". Skipped." );
+				continue;
+			}
+			final FeatureSerializer< ?, ?, AM > featureSerializer = serializers.get( featureKey );
+			if ( null == featureSerializer )
+			{
+				System.err.println( "Cannot find a serializer to read feature " + featureKey + ". Skipped." );
+				continue;
+			}
+			try
+			{
+				final Feature< ?, ? > feature = featureSerializer.deserialize( featureFile, model );
+				declareFeature( feature );
+			}
+			catch ( final IOException e )
+			{
+				System.err.println( "Could not deserialize feature " + featureKey + " from file " + featureFile + ":\n" + e.getMessage() );
+			}
+		}
+	}
+
+	private static final String getFeatureKeyFromFileName( final File featureFile )
+	{
+		final String name = featureFile.getName();
+		final int dotIndex = name.lastIndexOf( '.' );
+		return name.substring( 0, dotIndex );
+	}
+
+	private static final File makeFeatureFilePath( final File baseFolder, final String featureKey )
+	{
+		return new File( baseFolder, new File(FEATURE_FOLDER, featureKey + RAW_EXTENSION ).getPath() );
+	}
+
+
+	private static final String FEATURE_FOLDER = "Features";
+
+	private static final String RAW_EXTENSION = ".raw";
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
@@ -8,12 +8,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.revised.model.AbstractModel;
 
 /**
  * Default feature model.
  *
  * @author Jean-Yves Tinevez
+ * @param <AM>
+ *            the type of the model over which the features stored in this
+ *            feature model are defined.
  */
 public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implements FeatureModel< AM >
 {
@@ -69,7 +73,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 
 	@SuppressWarnings( "unchecked" )
 	@Override
-	public void saveRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model )
+	public void saveRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model, final GraphToFileIdMap< ?, ? > graphToFileIdMap )
 	{
 		final File featureFolder = new File( baseFolder, FEATURE_FOLDER );
 		if (!featureFolder.exists())
@@ -100,7 +104,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 			{
 				@SuppressWarnings( "rawtypes" )
 				final Feature feature = keyToFeature.get( featureKey );
-				featureSerializer.serialize( feature, featureFilePath, model );
+				featureSerializer.serialize( feature, featureFilePath, model, graphToFileIdMap );
 			}
 			catch ( final IOException e )
 			{
@@ -110,7 +114,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 	}
 
 	@Override
-	public void loadRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final FileIdToGraphMap< ?, ? > fileIdToGraphMap )
+	public void loadRaw( final File baseFolder, final Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM model, final FileIdToGraphMap< ?, ? > fileIdToGraphMap )
 	{
 		clear();
 		final File featureFolder = new File( baseFolder, FEATURE_FOLDER );
@@ -135,7 +139,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 			}
 			try
 			{
-				final Feature< ?, ? > feature = featureSerializer.deserialize( featureFile, fileIdToGraphMap );
+				final Feature< ?, ? > feature = featureSerializer.deserialize( featureFile, model, fileIdToGraphMap );
 				declareFeature( feature );
 			}
 			catch ( final IOException e )

--- a/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
@@ -162,7 +162,7 @@ public class DefaultFeatureModel< AM extends AbstractModel< ?, ?, ? > > implemen
 	}
 
 
-	private static final String FEATURE_FOLDER = "Features";
+	private static final String FEATURE_FOLDER = "features";
 
 	private static final String RAW_EXTENSION = ".raw";
 

--- a/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/DefaultFeatureModel.java
@@ -73,8 +73,8 @@ public class DefaultFeatureModel implements FeatureModel
 	@Override
 	public void writeRaw( final ObjectOutputStream oos, final Map< Class< ? >, ObjectToFileIdMap< ? > > fileIdMaps ) throws IOException
 	{
+		// Collect feature to write and order them by target class.
 		final Map<Class< ? >, PropertyMapSerializers< ? > > serializerMap = new HashMap<>();
-
 		for ( final String featureKey : keyToFeature.keySet() )
 		{
 			final Feature< ?, ? > feature = keyToFeature.get( featureKey );
@@ -91,10 +91,20 @@ public class DefaultFeatureModel implements FeatureModel
 			propertyMapSerializers.put( featureKey, serializer );
 		}
 
-		for ( final Class< ? > targetClass : serializerMap.keySet() )
+		// Write several blocks of features, one by target class.
+		// Order imposed by the key of fileIdMaps.
+		for ( final Class< ? > targetClass : fileIdMaps.keySet() )
 		{
 			final PropertyMapSerializers serializers = serializerMap.get( targetClass );
-			final ObjectToFileIdMap idmap = fileIdMaps.get(targetClass);
+			if ( null == serializers )
+				continue;
+
+			final ObjectToFileIdMap idmap = fileIdMaps.get( targetClass );
+			if (null == idmap)
+			{
+				System.err.println( "Error while writing features. Do not have a file id map for target class " + targetClass );
+				continue;
+			}
 			RawPropertyIO.writePropertyMaps( idmap, serializers, oos );
 		}
 	}

--- a/src/main/java/org/mastodon/revised/model/feature/Feature.java
+++ b/src/main/java/org/mastodon/revised/model/feature/Feature.java
@@ -2,6 +2,7 @@ package org.mastodon.revised.model.feature;
 
 import java.util.Map;
 
+import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.PropertyMap;
 
 /**
@@ -33,10 +34,10 @@ import org.mastodon.properties.PropertyMap;
  *
  * @param <O>
  *            the type of the object this feature is defined for (target).
- * @param <K>
+ * @param <M>
  *            the type of the property map used to store feature values.
  */
-public class Feature< O, K extends PropertyMap< O, ? > >
+public class Feature< O, M extends PropertyMap< O, ? > >
 {
 
 	/**
@@ -47,7 +48,7 @@ public class Feature< O, K extends PropertyMap< O, ? > >
 	/**
 	 * The feature property map.
 	 */
-	private final K propertyMap;
+	private final M propertyMap;
 
 	/**
 	 * The feature projections, stored as a map from projection names to
@@ -59,6 +60,11 @@ public class Feature< O, K extends PropertyMap< O, ? > >
 	 * The class of the feature target.
 	 */
 	private final Class< O > targetClass;
+
+	/**
+	 * The serializer that will be used to serialize this feature.
+	 */
+	private final PropertyMapSerializer< O, M > serializer;
 
 	/**
 	 * Creates a new immutable feature instance.
@@ -73,13 +79,17 @@ public class Feature< O, K extends PropertyMap< O, ? > >
 	 * @param projections
 	 *            The feature projections, stored as a map from projection names
 	 *            to projections.
+	 * @param serializer
+	 *            A serializer that can serialize the property map of this
+	 *            feature.
 	 */
-	public Feature( final String key, final Class< O > targetClass, final K propertyMap, final Map< String, FeatureProjection< O > > projections )
+	public Feature( final String key, final Class< O > targetClass, final M propertyMap, final Map< String, FeatureProjection< O > > projections, final PropertyMapSerializer< O, M > serializer )
 	{
 		this.key = key;
 		this.targetClass = targetClass;
 		this.propertyMap = propertyMap;
 		this.projections = projections;
+		this.serializer = serializer;
 	}
 
 	/**
@@ -97,7 +107,7 @@ public class Feature< O, K extends PropertyMap< O, ? > >
 	 *
 	 * @return the property map.
 	 */
-	public K getPropertyMap()
+	public M getPropertyMap()
 	{
 		return propertyMap;
 	}
@@ -122,5 +132,16 @@ public class Feature< O, K extends PropertyMap< O, ? > >
 	public Class< O > getTargetClass()
 	{
 		return targetClass;
+	}
+
+	/**
+	 * Returns a property map serializer that can serialize the property map of
+	 * this feature.
+	 *
+	 * @return a suitable serializer.
+	 */
+	public PropertyMapSerializer< ?, ? > getSerializer()
+	{
+		return serializer;
 	}
 }

--- a/src/main/java/org/mastodon/revised/model/feature/Feature.java
+++ b/src/main/java/org/mastodon/revised/model/feature/Feature.java
@@ -2,7 +2,6 @@ package org.mastodon.revised.model.feature;
 
 import java.util.Map;
 
-import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.PropertyMap;
 
 /**
@@ -62,11 +61,6 @@ public class Feature< O, M extends PropertyMap< O, ? > >
 	private final Class< O > targetClass;
 
 	/**
-	 * The serializer that will be used to serialize this feature.
-	 */
-	private final PropertyMapSerializer< O, M > serializer;
-
-	/**
 	 * Creates a new immutable feature instance.
 	 *
 	 * @param key
@@ -79,17 +73,13 @@ public class Feature< O, M extends PropertyMap< O, ? > >
 	 * @param projections
 	 *            The feature projections, stored as a map from projection names
 	 *            to projections.
-	 * @param serializer
-	 *            A serializer that can serialize the property map of this
-	 *            feature.
 	 */
-	public Feature( final String key, final Class< O > targetClass, final M propertyMap, final Map< String, FeatureProjection< O > > projections, final PropertyMapSerializer< O, M > serializer )
+	public Feature( final String key, final Class< O > targetClass, final M propertyMap, final Map< String, FeatureProjection< O > > projections )
 	{
 		this.key = key;
 		this.targetClass = targetClass;
 		this.propertyMap = propertyMap;
 		this.projections = projections;
-		this.serializer = serializer;
 	}
 
 	/**
@@ -132,16 +122,5 @@ public class Feature< O, M extends PropertyMap< O, ? > >
 	public Class< O > getTargetClass()
 	{
 		return targetClass;
-	}
-
-	/**
-	 * Returns a property map serializer that can serialize the property map of
-	 * this feature.
-	 *
-	 * @return a suitable serializer.
-	 */
-	public PropertyMapSerializer< ?, ? > getSerializer()
-	{
-		return serializer;
 	}
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
@@ -2,7 +2,6 @@ package org.mastodon.revised.model.feature;
 
 import java.util.Set;
 
-import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.AbstractModel;
 import org.scijava.plugin.SciJavaPlugin;
@@ -52,25 +51,11 @@ public interface FeatureComputer< O, M extends PropertyMap< O, ? >, AM extends A
 	public String getKey();
 
 	/**
-	 * Creates a new, empty property map, that can be used to store the values
-	 * of this feature.
-	 *
-	 * @param model
-	 *            the model against which to create the property map.
-	 * @return a new, empty property map.
-	 */
-	public M createPropertyMap( AM model );
-
-	/**
 	 * Returns a feature serializer that can de/serialize <b>this specific
 	 * feature</b> from/to a raw file.
 	 *
-	 * @param pm
-	 *            the property map that will be serialized to disk when saving,
-	 *            or filled with values fetched from disk when loading.
-	 *
 	 * @return a feature serializer.
 	 */
-	public PropertyMapSerializer< O, M > getSerializer( M pm );
+	public FeatureSerializer< O, M, AM > getSerializer();
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
@@ -1,9 +1,8 @@
 package org.mastodon.revised.model.feature;
 
-import java.io.ObjectInputStream;
 import java.util.Set;
 
-import org.mastodon.io.FileIdToObjectMap;
+import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.AbstractModel;
 import org.scijava.plugin.SciJavaPlugin;
 
@@ -13,10 +12,14 @@ import org.scijava.plugin.SciJavaPlugin;
  * Concrete implementations must be stateless, without side effects. A computer
  * must generate a single feature, however a feature does not have to be scalar.
  *
+ * @param <O>
+ *            the type of the objects this feature is defined for.
+ * @param <M>
+ *            the type of the property map this feature relies on.
  * @param <AM>
  *            the type of the model the feature is calculated on and stored in.
  */
-public interface FeatureComputer< AM extends AbstractModel< ?, ?, ? > > extends SciJavaPlugin
+public interface FeatureComputer< O, M extends PropertyMap< O, ? >, AM extends AbstractModel< ?, ?, ? > > extends SciJavaPlugin
 {
 
 	/**
@@ -38,7 +41,7 @@ public interface FeatureComputer< AM extends AbstractModel< ?, ?, ? > > extends 
 	 * @param model
 	 *            the model to retrieve objects from.
 	 */
-	public Feature< ?, ? > compute( final AM model );
+	public Feature< O, M > compute( final AM model );
 
 	/**
 	 * Returns the string key of the feature calculated by this computer.
@@ -48,17 +51,11 @@ public interface FeatureComputer< AM extends AbstractModel< ?, ?, ? > > extends 
 	public String getKey();
 
 	/**
-	 * Deserializes the {@link Feature} object calculated by this class,
-	 * taking values from in input stream.
+	 * Returns a feature serializer that can de/serialize <b>this specific
+	 * feature</b> from/to a raw file.
 	 *
-	 * @param ois
-	 *            The input stream. Will not be closed.
-	 * @param fileIdToObjectMap
-	 *            A mapping between file Ids to objects.
-	 * @param model
-	 *            The model the feature is defined on. This object is only used
-	 *            to instantiate property maps.
-	 * @return a new feature object.
+	 * @return a feature serializer.
 	 */
-	public Feature< ?, ? > deserialize( ObjectInputStream ois, FileIdToObjectMap< ? > fileIdToObjectMap, AM model );
+	public FeatureSerializer< O, M, AM > getSerializer();
+
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
@@ -1,7 +1,9 @@
 package org.mastodon.revised.model.feature;
 
+import java.io.ObjectInputStream;
 import java.util.Set;
 
+import org.mastodon.io.FileIdToObjectMap;
 import org.mastodon.revised.model.AbstractModel;
 import org.scijava.plugin.SciJavaPlugin;
 
@@ -44,4 +46,19 @@ public interface FeatureComputer< AM extends AbstractModel< ?, ?, ? > > extends 
 	 * @return the feature key.
 	 */
 	public String getKey();
+
+	/**
+	 * Deserializes the {@link Feature} object calculated by this class,
+	 * taking values from in input stream.
+	 *
+	 * @param ois
+	 *            The input stream. Will not be closed.
+	 * @param fileIdToObjectMap
+	 *            A mapping between file Ids to objects.
+	 * @param model
+	 *            The model the feature is defined on. This object is only used
+	 *            to instantiate property maps.
+	 * @return a new feature object.
+	 */
+	public Feature< ?, ? > deserialize( ObjectInputStream ois, FileIdToObjectMap< ? > fileIdToObjectMap, AM model );
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureComputer.java
@@ -2,6 +2,7 @@ package org.mastodon.revised.model.feature;
 
 import java.util.Set;
 
+import org.mastodon.io.properties.PropertyMapSerializer;
 import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.model.AbstractModel;
 import org.scijava.plugin.SciJavaPlugin;
@@ -51,11 +52,25 @@ public interface FeatureComputer< O, M extends PropertyMap< O, ? >, AM extends A
 	public String getKey();
 
 	/**
+	 * Creates a new, empty property map, that can be used to store the values
+	 * of this feature.
+	 *
+	 * @param model
+	 *            the model against which to create the property map.
+	 * @return a new, empty property map.
+	 */
+	public M createPropertyMap( AM model );
+
+	/**
 	 * Returns a feature serializer that can de/serialize <b>this specific
 	 * feature</b> from/to a raw file.
 	 *
+	 * @param pm
+	 *            the property map that will be serialized to disk when saving,
+	 *            or filled with values fetched from disk when loading.
+	 *
 	 * @return a feature serializer.
 	 */
-	public FeatureSerializer< O, M, AM > getSerializer();
+	public PropertyMapSerializer< O, M > getSerializer( M pm );
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureComputerService.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureComputerService.java
@@ -23,7 +23,7 @@ public interface FeatureComputerService< AM extends AbstractModel< ?, ?, ? > > e
 	 *
 	 * @return the available feature computers.
 	 */
-	public Collection< FeatureComputer< AM > > getFeatureComputers();
+	public Collection< FeatureComputer< ?, ?, AM > > getFeatureComputers();
 
 	/**
 	 * Executes feature computation for the specified computers on the specified
@@ -41,6 +41,6 @@ public interface FeatureComputerService< AM extends AbstractModel< ?, ?, ? > > e
 	 *            a progress listener, used to report calculation progress.
 	 * @return <code>true</code> if computation terminated successfully.
 	 */
-	public boolean compute( AM model, FeatureModel featureModel, Set< FeatureComputer< AM > > selectedComputers, ProgressListener progressListener );
+	public boolean compute( AM model, FeatureModel< AM > featureModel, Set< FeatureComputer< ?, ?, AM > > selectedComputers, ProgressListener progressListener );
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
 import org.mastodon.revised.model.AbstractModel;
 
 /**
@@ -68,9 +69,10 @@ public interface FeatureModel< AM extends AbstractModel< ?, ?, ? > >
 	 *            the map of serializers to use to save features. If a
 	 *            serializer is not found in the map for a feature with a
 	 *            specific key, that feature is not loaded.
-	 * @param support
-	 *            the model on which features are defined.
+	 * @param fileIdToGraphMap
+	 *            the map collection that links file object ids to graph object
+	 *            ids.
 	 */
-	public void loadRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, AM support );
+	public void loadRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, FileIdToGraphMap< ?, ? > fileIdToGraphMap );
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
@@ -1,11 +1,10 @@
 package org.mastodon.revised.model.feature;
 
-import java.io.IOException;
-import java.io.ObjectOutputStream;
+import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
-import org.mastodon.io.ObjectToFileIdMap;
+import org.mastodon.revised.model.AbstractModel;
 
 /**
  * Interface for feature models, classes that manage a collection of features in
@@ -13,7 +12,7 @@ import org.mastodon.io.ObjectToFileIdMap;
  *
  * @author Jean-Yves Tinevez
  */
-public interface FeatureModel
+public interface FeatureModel< AM extends AbstractModel< ?, ?, ? > >
 {
 
 	public Set< Feature< ?, ? > > getFeatureSet( Class< ? > targetClass );
@@ -43,23 +42,35 @@ public interface FeatureModel
 	public Feature< ?, ? > getFeature( String key );
 
 	/**
-	 * Appends the features of this model to the specified stream, using the
-	 * specified mapping from object feature are defined for, to the file ids
-	 * they are saved under.
-	 * <p>
-	 * Because the feature model can deal with features defined over several
-	 * classes of objects, the mapping is specified as a map from object class
-	 * to actual mapping.
-	 * There must be a mapping for each class of target objects that has a
-	 * feature in this model, in the specified map.
+	 * Saves the {@link Feature}s managed by this feature model as individual
+	 * raw files.
 	 *
-	 *
-	 * @param oos
-	 *            The stream to appends features to. Will not be closed.
-	 * @param fileIdMaps
-	 *            the mapping from object to file ids.
-	 * @throws IOException
+	 * @param projectFolder
+	 *            the feature will be saved in a sub-folder of this project
+	 *            folder.
+	 * @param serializers
+	 *            the map of serializers to use to save features. If a
+	 *            serializer is not found in the map for a feature with a
+	 *            specific key, that feature is not saved.
+	 * @param support
+	 *            the model on which features are defined.
 	 */
-	public void writeRaw( ObjectOutputStream oos, Map< Class< ? >, ObjectToFileIdMap< ? > > fileIdMaps ) throws IOException;
+	public void saveRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, AM support );
+
+	/**
+	 * Clears this feature model and loads the {@link Feature}s from files in a
+	 * sub-folder of the specified project folder.
+	 *
+	 * @param projectFolder
+	 *            the feature will be loaded from a sub-folder of this project
+	 *            folder.
+	 * @param serializers
+	 *            the map of serializers to use to save features. If a
+	 *            serializer is not found in the map for a feature with a
+	 *            specific key, that feature is not loaded.
+	 * @param support
+	 *            the model on which features are defined.
+	 */
+	public void loadRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, AM support );
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
@@ -1,6 +1,11 @@
 package org.mastodon.revised.model.feature;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Map;
 import java.util.Set;
+
+import org.mastodon.io.ObjectToFileIdMap;
 
 /**
  * Interface for feature models, classes that manage a collection of features in
@@ -36,5 +41,25 @@ public interface FeatureModel
 	 *         key is not registered in this model.
 	 */
 	public Feature< ?, ? > getFeature( String key );
+
+	/**
+	 * Appends the features of this model to the specified stream, using the
+	 * specified mapping from object feature are defined for, to the file ids
+	 * they are saved under.
+	 * <p>
+	 * Because the feature model can deal with features defined over several
+	 * classes of objects, the mapping is specified as a map from object class
+	 * to actual mapping.
+	 * There must be a mapping for each class of target objects that has a
+	 * feature in this model, in the specified map.
+	 *
+	 *
+	 * @param oos
+	 *            The stream to appends features to. Will not be closed.
+	 * @param fileIdMaps
+	 *            the mapping from object to file ids.
+	 * @throws IOException
+	 */
+	public void writeRaw( ObjectOutputStream oos, Map< Class< ? >, ObjectToFileIdMap< ? > > fileIdMaps ) throws IOException;
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureModel.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.revised.model.AbstractModel;
 
 /**
@@ -12,6 +13,9 @@ import org.mastodon.revised.model.AbstractModel;
  * a model graph.
  *
  * @author Jean-Yves Tinevez
+ * @param <AM>
+ *            the type of the model over which the features stored in this
+ *            feature model are defined.
  */
 public interface FeatureModel< AM extends AbstractModel< ?, ?, ? > >
 {
@@ -55,8 +59,11 @@ public interface FeatureModel< AM extends AbstractModel< ?, ?, ? > >
 	 *            specific key, that feature is not saved.
 	 * @param support
 	 *            the model on which features are defined.
+	 * @param graphToFileIdMap
+	 *            the map collection that linkg graph object ids to file object
+	 *            ids.
 	 */
-	public void saveRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, AM support );
+	public void saveRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, AM support, GraphToFileIdMap< ?, ? > graphToFileIdMap );
 
 	/**
 	 * Clears this feature model and loads the {@link Feature}s from files in a
@@ -69,10 +76,13 @@ public interface FeatureModel< AM extends AbstractModel< ?, ?, ? > >
 	 *            the map of serializers to use to save features. If a
 	 *            serializer is not found in the map for a feature with a
 	 *            specific key, that feature is not loaded.
+	 * @param support
+	 *            the model on which features are defined.
 	 * @param fileIdToGraphMap
 	 *            the map collection that links file object ids to graph object
 	 *            ids.
 	 */
-	public void loadRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, FileIdToGraphMap< ?, ? > fileIdToGraphMap );
+	public void loadRaw( File projectFolder, Map< String, FeatureSerializer< ?, ?, AM > > serializers, final AM support, FileIdToGraphMap< ?, ? > fileIdToGraphMap );
+
 
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.properties.PropertyMap;
 
 /**
@@ -33,7 +34,7 @@ public interface FeatureSerializer< O, M extends PropertyMap< O, ? >, AM >
 	 * @throws IOException
 	 *             if an IO error occurs during serialization.
 	 */
-	public void serialize( Feature< O, M > feature, File file, AM support ) throws IOException;
+	public void serialize( Feature< O, M > feature, File file, AM support, final GraphToFileIdMap< ?, ? > idmap ) throws IOException;
 
 	/**
 	 * Deserializes a specific feature from the specified file.

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
@@ -3,6 +3,7 @@ package org.mastodon.revised.model.feature;
 import java.io.File;
 import java.io.IOException;
 
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
 import org.mastodon.properties.PropertyMap;
 
 /**
@@ -46,9 +47,11 @@ public interface FeatureSerializer< O, M extends PropertyMap< O, ? >, AM >
 	 * @param support
 	 *            the model the feature to deserialized is defined on. Must
 	 *            itself be properly deserialized and unmodified since.
+	 * @param fileIdToGraphMap the map collection that links file object ids to graph object
+	 *            ids.
 	 * @return the feature.
 	 * @throws IOException
 	 *             if an IO error occurs during deserialization.
 	 */
-	public Feature< O, M > deserialize( File file, AM support ) throws IOException;
+	public Feature< O, M > deserialize( File file, AM support, FileIdToGraphMap< ?, ? > fileIdToGraphMap ) throws IOException;
 }

--- a/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
+++ b/src/main/java/org/mastodon/revised/model/feature/FeatureSerializer.java
@@ -1,0 +1,54 @@
+package org.mastodon.revised.model.feature;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.mastodon.properties.PropertyMap;
+
+/**
+ * Input/Output for a specific feature.
+ * <p>
+ *
+ * @param <O>
+ *            the type of the objects the feature is defined for.
+ * @param <M>
+ *            the type of the property map the feature relies on.
+ * @param <AM>
+ *            the type of the model the feature is calculated on and stored in.
+ * @author Jean-Yves Tinevez
+ */
+public interface FeatureSerializer< O, M extends PropertyMap< O, ? >, AM >
+{
+
+	/**
+	 * Serializes the specified feature to a raw file.
+	 *
+	 * @param feature
+	 *            the feature to serialize.
+	 * @param file
+	 *            the file to write.
+	 * @param support
+	 *            the model the specified feature is defined on.
+	 * @throws IOException
+	 *             if an IO error occurs during serialization.
+	 */
+	public void serialize( Feature< O, M > feature, File file, AM support ) throws IOException;
+
+	/**
+	 * Deserializes a specific feature from the specified file.
+	 * <p>
+	 * The feature to deserialize must have been serialized with the same
+	 * {@link FeatureSerializer}. Otherwise deserialization will cause an
+	 * undefined behavior.
+	 *
+	 * @param file
+	 *            the raw file to deserialize.
+	 * @param support
+	 *            the model the feature to deserialized is defined on. Must
+	 *            itself be properly deserialized and unmodified since.
+	 * @return the feature.
+	 * @throws IOException
+	 *             if an IO error occurs during deserialization.
+	 */
+	public Feature< O, M > deserialize( File file, AM support ) throws IOException;
+}

--- a/src/main/java/org/mastodon/revised/model/mamut/Model.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/Model.java
@@ -10,8 +10,8 @@ import java.util.Map;
 
 import org.mastodon.graph.ReadOnlyGraph;
 import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
+import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.properties.Property;
-import org.mastodon.properties.PropertyMap;
 import org.mastodon.revised.mamut.feature.MamutFeatureComputerService;
 import org.mastodon.revised.model.AbstractModel;
 import org.mastodon.revised.model.feature.DefaultFeatureModel;
@@ -80,7 +80,7 @@ public class Model extends AbstractModel< ModelGraph, Spot, Link > implements Un
 
 		final List< Property< Link > > edgeUndoableProperties = new ArrayList<>();
 
-		featureModel = new DefaultFeatureModel< Model >();
+		featureModel = new DefaultFeatureModel< >();
 
 		undoRecorder = new GraphUndoRecorder<>(
 				initialCapacity,
@@ -119,11 +119,8 @@ public class Model extends AbstractModel< ModelGraph, Spot, Link > implements Un
 		final Collection< FeatureComputer< ?, ?, Model > > featureComputers = featureComputerService.getFeatureComputers();
 		final Map< String, FeatureSerializer< ?, ?, Model > > featureSerializers = new HashMap<>( featureComputers.size() );
 		for ( final FeatureComputer featureComputer : featureComputers )
-		{
-			final PropertyMap pm = featureComputer.createPropertyMap( this );
-			featureSerializers.put( featureComputer.getKey(), ( FeatureSerializer< ?, ?, Model > ) featureComputer.getSerializer( pm ) );
-		}
-		featureModel.loadRaw( file.getParentFile(), featureSerializers, fileIdToGraphMap );
+			featureSerializers.put( featureComputer.getKey(), featureComputer.getSerializer() );
+		featureModel.loadRaw( file.getParentFile(), featureSerializers, this, fileIdToGraphMap );
 	}
 
 	/**
@@ -140,7 +137,7 @@ public class Model extends AbstractModel< ModelGraph, Spot, Link > implements Un
 	public void saveRaw( final File file ) throws IOException
 	{
 		// Serialize model graph.
-		modelGraph.saveRaw( file, ModelSerializer.getInstance() );
+		final GraphToFileIdMap< Spot, Link > graphToFileIdMap = modelGraph.saveRaw( file, ModelSerializer.getInstance() );
 
 		// Serialize feature model.
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
@@ -148,7 +145,7 @@ public class Model extends AbstractModel< ModelGraph, Spot, Link > implements Un
 		final Map< String, FeatureSerializer< ?, ?, Model > > featureSerializers = new HashMap<>( featureComputers.size() );
 		for ( final FeatureComputer< ?, ?, Model > featureComputer : featureComputers )
 			featureSerializers.put( featureComputer.getKey(), featureComputer.getSerializer() );
-		featureModel.saveRaw( file.getParentFile(), featureSerializers, this );
+		featureModel.saveRaw( file.getParentFile(), featureSerializers, this, graphToFileIdMap );
 	}
 
 	/**

--- a/src/main/java/org/mastodon/revised/model/mamut/Model.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/Model.java
@@ -1,21 +1,31 @@
 package org.mastodon.revised.model.mamut;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.mastodon.graph.ReadOnlyGraph;
+import org.mastodon.graph.io.RawGraphIO.FileIdToGraphMap;
 import org.mastodon.graph.io.RawGraphIO.GraphToFileIdMap;
 import org.mastodon.io.ObjectToFileIdMap;
 import org.mastodon.properties.Property;
+import org.mastodon.revised.mamut.feature.LinkFeatureComputer;
+import org.mastodon.revised.mamut.feature.MamutFeatureComputerService;
+import org.mastodon.revised.mamut.feature.SpotFeatureComputer;
 import org.mastodon.revised.model.AbstractModel;
 import org.mastodon.revised.model.feature.DefaultFeatureModel;
+import org.mastodon.revised.model.feature.Feature;
+import org.mastodon.revised.model.feature.FeatureComputer;
 import org.mastodon.revised.model.feature.FeatureModel;
 import org.mastodon.spatial.SpatioTemporalIndex;
 import org.mastodon.spatial.SpatioTemporalIndexImp;
@@ -85,12 +95,73 @@ public class Model extends AbstractModel< ModelGraph, Spot, Link > implements Un
 	 *
 	 * @param file
 	 *            the raw file to load.
+	 * @param featureComputerService
+	 *            the MaMuT feature computer service, used to retrieve the
+	 *            feature computers that know how to deserialize feature values.
 	 * @throws IOException
 	 *             if an I/O error occurs while reading the file.
 	 */
-	public void loadRaw( final File file ) throws IOException
+	public void loadRaw( final File file, final MamutFeatureComputerService featureComputerService ) throws IOException
 	{
-		modelGraph.loadRaw( file, ModelSerializer.getInstance() );
+		final FileInputStream fis = new FileInputStream( file );
+		final ObjectInputStream ois = new ObjectInputStream( new BufferedInputStream( fis, 1024 * 1024 ) );
+
+		/*
+		 * Read the model-graph.
+		 */
+		final FileIdToGraphMap< Spot, Link > fileIdMap = modelGraph.readRaw( ois, ModelSerializer.getInstance() );
+
+		/*
+		 * Read the feature values.
+		 */
+
+		featureModel.clear();
+		final Collection< FeatureComputer< Model > > featureComputers = featureComputerService.getFeatureComputers();
+		try
+		{
+			final String[] keys = ( String[] ) ois.readObject();
+			for ( final String key : keys )
+			{
+				FeatureComputer< Model > featureComputer = null;
+				for ( final FeatureComputer<Model> fc : featureComputers )
+				{
+					if (fc.getKey().equals( key ))
+					{
+						featureComputer = fc;
+						break;
+					}
+				}
+				if (null == featureComputer)
+				{
+					System.err.println( "Could not find a feature computer with key " + key + ". Skipping." );
+					// TODO If we skip we cannot read the next ones. What to do?
+					continue;
+				}
+
+				final Feature<?,?> feature;
+				if (featureComputer instanceof SpotFeatureComputer)
+				{
+					 feature = featureComputer.deserialize(ois, fileIdMap.vertices(), this);
+				}
+				else if (featureComputer instanceof LinkFeatureComputer)
+				{
+					 feature = featureComputer.deserialize(ois, fileIdMap.edges(), this);
+				}
+				else
+				{
+					System.err.println( "Unknown target class for feature computer " + featureComputer + ". Skipping" );
+					// TODO If we skip we cannot read the next ones. What to do?
+					continue;
+				}
+				featureModel.declareFeature( feature );
+			}
+		}
+		catch ( final ClassNotFoundException e )
+		{
+			e.printStackTrace();
+		}
+
+		ois.close();
 	}
 
 	/**

--- a/src/test/java/org/mastodon/graph/features/calculator/EdgeFeatureCalculatorExample.java
+++ b/src/test/java/org/mastodon/graph/features/calculator/EdgeFeatureCalculatorExample.java
@@ -1,7 +1,5 @@
 package org.mastodon.graph.features.calculator;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Locale;
 
 import org.mastodon.collection.RefCollections;
@@ -102,22 +100,5 @@ public class EdgeFeatureCalculatorExample
 			else
 				System.out.println( String.format( Locale.US, "For root %s, mean displacement = %.3f (N = %d).", root.getLabel(), ( dr.get() / n.get() ), n.get() ) );
 		}
-	}
-
-	public static void main( final String[] args ) throws IOException
-	{
-		long start = System.currentTimeMillis();
-		final String modelFile = "samples/model_revised.raw";
-		final Model model = new Model();
-		System.out.print( "Loading data: " + modelFile + "... " );
-		model.loadRaw( new File( modelFile ) );
-		long end = System.currentTimeMillis();
-		System.out.println( "Done in " + ( end - start ) + " ms." );
-
-		start = System.currentTimeMillis();
-		compute( model );
-		end = System.currentTimeMillis();
-		System.out.println( "Calculation done in " + ( end - start ) + " ms." );
-
 	}
 }


### PR DESCRIPTION
- Feature de/serialization is triggered from the `FeatureModel`, when the
model is being serialized itself.

- Features are de/serialized from/to a subfolder of the project folder.
With the `DefaultFeatureModel,` this subfolder is 'Features'.

- Each feature is saved to an individual file, named with the key of the
feature + '.raw'.

- Specialized classes, derived from the interface `FeatureSerializer`,
are in charge of the de/serialization of individual features. There is
*one* specific `FeatureSerializer` for each feature. This is necessary
since we do not know what is the type of values used by a feature.

- Concrete `FeatureSerializer` implementations are provided by the
`FeatureComputer`s. Since these classes (normally written by 3rd party
users) are the ones that know how to generate a feature, they also know
how to de/serialize them.

- So the model needs to know what are the `FeatureComputer`s when saving
and loading. Since they are provided by SciJava plugin discovery mechanism
(within the FeautureComputerService), the model needs to access a SciJava
`Context`. Now each `Model` instance has its own context (lightweight,
only instantiated with the `MamutFeatureComputerService`). The context
instance has then been removed from the `MainWindow` class, and the later
uses the context of the model it manages.
