### PR TITLE
Fix hide-show toolbar action resizing the view.

### DIFF
--- a/src/main/java/org/mastodon/app/ui/ViewFrame.java
+++ b/src/main/java/org/mastodon/app/ui/ViewFrame.java
@@ -1,6 +1,7 @@
 package org.mastodon.app.ui;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.BoxLayout;
@@ -77,6 +78,7 @@ public class ViewFrame extends JFrame
 	{
 		if ( isSettingsPanelVisible != visible )
 		{
+			final Dimension size = getSize();
 			isSettingsPanelVisible = visible;
 			if ( visible )
 			{
@@ -89,6 +91,7 @@ public class ViewFrame extends JFrame
 				settingsPanel.setVisible( false );
 			}
 			invalidate();
+			setPreferredSize( size );
 			pack();
 		}
 	}

--- a/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
@@ -134,11 +134,11 @@ public class ProjectManager
 
 	public synchronized void loadProject()
 	{
-		final String fn = proposedProjectFolder == null
-				? ( project == null
-						? null
-						: project.getProjectFolder().getAbsolutePath() )
-				: proposedProjectFolder.getAbsolutePath();
+		String fn = null;
+		if ( proposedProjectFolder != null )
+			fn = proposedProjectFolder.getAbsolutePath();
+		else if ( project != null && project.getProjectFolder() != null )
+			fn = project.getProjectFolder().getAbsolutePath();
 		final Component parent = null; // TODO
 		final File file = FileChooser.chooseFile(
 				parent,


### PR DESCRIPTION
Prior to this commit, hiding/showing the toolbar of Mastodon views (e.g. by pressing 'T' in TrackScheme) caused the view to be resized to its default size.

This commit fixes this bug by setting the preferred size of the view frame before re-packing it before deletion/insertion of the toolbar.