### PR TITLE
Add an action to close a view window.

### DIFF
--- a/src/main/java/org/mastodon/app/ui/CloseWindowActions.java
+++ b/src/main/java/org/mastodon/app/ui/CloseWindowActions.java
@@ -1,0 +1,77 @@
+package org.mastodon.app.ui;
+
+import static org.mastodon.app.ui.MastodonFrameViewActions.CLOSE_WINDOW;
+import static org.mastodon.app.ui.MastodonFrameViewActions.CLOSE_WINDOW_KEYS;
+
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.WindowEvent;
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+import org.scijava.ui.behaviour.util.Actions;
+
+public class CloseWindowActions
+{
+	public static final String CLOSE_DIALOG = "close dialog window";
+
+	static final String[] CLOSE_DIALOG_KEYS = new String[] { "ctrl W", "meta W", "ESCAPE" };
+
+	/**
+	 * Create a close window action and install it in the specified
+	 * {@link Actions}.
+	 *
+	 * @param actions
+	 *            Actions are added here.
+	 * @param frame
+	 *            Actions are targeted at this window.
+	 */
+	public static void install(
+			final Actions actions,
+			final JFrame frame )
+	{
+		actions.namedAction( new CloseWindowAction( frame, CLOSE_WINDOW ), CLOSE_WINDOW_KEYS );
+	}
+
+	/**
+	 * Create a close dialog action and install it in the specified
+	 * {@link Actions}.
+	 *
+	 * @param actions
+	 *            Actions are added here.
+	 * @param dialog
+	 *            Actions are targeted at this dialog.
+	 */
+	public static void install(
+			final Actions actions,
+			final JDialog dialog )
+	{
+		actions.namedAction( new CloseWindowAction( dialog, CLOSE_DIALOG ), CLOSE_DIALOG_KEYS );
+	}
+
+	private static class CloseWindowAction extends AbstractNamedAction
+	{
+		private static final long serialVersionUID = 1L;
+
+		private final Window window;
+
+		public CloseWindowAction( final Window window, final String name )
+		{
+			super( name );
+			this.window = window;
+		}
+
+		@Override
+		public void actionPerformed( final ActionEvent e )
+		{
+			/*
+			 * To properly close the view, we send it a WINDOW_CLOSING event.
+			 * This way, the listeners of the JFrame are called and the closing
+			 * happens gracefully within Mastodon.
+			 */
+			window.dispatchEvent( new WindowEvent( window, WindowEvent.WINDOW_CLOSING ) );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
+++ b/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
@@ -18,7 +18,7 @@ public class MastodonFrameViewActions
 
 	static final String[] TOGGLE_SETTINGS_PANEL_KEYS = new String[] { "T" };
 
-	static final String[] CLOSE_WINDOW_KEYS = new String[] { "ctrl W" };
+	static final String[] CLOSE_WINDOW_KEYS = new String[] { "ctrl W", "meta W" };
 
 	private final MastodonFrameView< ?, ?, ?, ?, ?, ? > view;
 

--- a/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
+++ b/src/main/java/org/mastodon/app/ui/MastodonFrameViewActions.java
@@ -3,6 +3,7 @@ package org.mastodon.app.ui;
 import java.awt.event.ActionEvent;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.WindowEvent;
 
 import org.mastodon.revised.util.HasSelectedState;
 import org.mastodon.util.Listeners;
@@ -13,11 +14,17 @@ public class MastodonFrameViewActions
 {
 	public static final String TOGGLE_SETTINGS_PANEL = "toggle settings panel";
 
+	public static final String CLOSE_WINDOW = "close window";
+
 	static final String[] TOGGLE_SETTINGS_PANEL_KEYS = new String[] { "T" };
+
+	static final String[] CLOSE_WINDOW_KEYS = new String[] { "ctrl W" };
 
 	private final MastodonFrameView< ?, ?, ?, ?, ?, ? > view;
 
 	private final ToggleSettingsPanelAction toggleSettingsPanelAction;
+
+	private final CloseWindowAction closeWindowAction;
 
 	/**
 	 * Create Mastodon view actions and install them in the specified
@@ -35,14 +42,37 @@ public class MastodonFrameViewActions
 		final MastodonFrameViewActions ba = new MastodonFrameViewActions( view );
 
 		actions.namedAction( ba.toggleSettingsPanelAction, TOGGLE_SETTINGS_PANEL_KEYS );
+		actions.namedAction( ba.closeWindowAction, CLOSE_WINDOW_KEYS );
 	}
 
 	private MastodonFrameViewActions( final MastodonFrameView< ?, ?, ?, ?, ?, ? > view )
 	{
 		this.view = view;
 		toggleSettingsPanelAction = new ToggleSettingsPanelAction( TOGGLE_SETTINGS_PANEL );
-
+		closeWindowAction = new CloseWindowAction( CLOSE_WINDOW );
 		// TODO: add group (lock...) select actions
+	}
+
+	private class CloseWindowAction extends AbstractNamedAction
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		public CloseWindowAction( final String name )
+		{
+			super( name );
+		}
+
+		@Override
+		public void actionPerformed( final ActionEvent e )
+		{
+			/*
+			 * To properly close the view, we send it a WINDOW_CLOSING event.
+			 * This way, the listeners of the JFrame are called and the closing
+			 * happens gracefully within Mastodon.
+			 */
+			view.getFrame().dispatchEvent( new WindowEvent( view.getFrame(), WindowEvent.WINDOW_CLOSING ) );
+		}
 	}
 
 	private class ToggleSettingsPanelAction extends AbstractNamedAction implements HasSelectedState

--- a/src/main/java/org/mastodon/revised/mamut/PreferencesDialog.java
+++ b/src/main/java/org/mastodon/revised/mamut/PreferencesDialog.java
@@ -5,11 +5,17 @@ import java.awt.Frame;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.WindowConstants;
 
+import org.mastodon.app.ui.CloseWindowActions;
 import org.mastodon.app.ui.settings.SettingsPage;
 import org.mastodon.app.ui.settings.SettingsPanel;
+import org.mastodon.revised.ui.keymap.Keymap;
+import org.scijava.ui.behaviour.util.Actions;
 
 public class PreferencesDialog extends JDialog
 {
@@ -17,14 +23,17 @@ public class PreferencesDialog extends JDialog
 
 	private final SettingsPanel settingsPanel;
 
-	public PreferencesDialog( final Frame owner )
+	public PreferencesDialog(
+			final Frame owner,
+			final Keymap keymap,
+			final String[] keyConfigContexts )
 	{
 		super( owner, "Preferences", false );
 		settingsPanel = new SettingsPanel();
 		settingsPanel.onOk( () -> setVisible( false ) );
 		settingsPanel.onCancel( () -> setVisible( false ) );
 
-		setDefaultCloseOperation( WindowConstants.DO_NOTHING_ON_CLOSE );
+		setDefaultCloseOperation( WindowConstants.HIDE_ON_CLOSE );
 		addWindowListener( new WindowAdapter()
 		{
 			@Override
@@ -33,6 +42,13 @@ public class PreferencesDialog extends JDialog
 				settingsPanel.cancel();
 			}
 		} );
+
+		final ActionMap am = getRootPane().getActionMap();
+		final InputMap im = getRootPane().getInputMap( JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT );
+		final Actions actions = new Actions( im, am, keymap.getConfig(), keyConfigContexts );
+		CloseWindowActions.install( actions, this );
+
+		keymap.updateListeners().add( () -> actions.updateKeyConfig( keymap.getConfig() ) );
 
 		getContentPane().add( settingsPanel, BorderLayout.CENTER );
 		pack();

--- a/src/main/java/org/mastodon/revised/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/WindowManager.java
@@ -110,7 +110,7 @@ public class WindowManager
 		globalAppActions.namedAction( newTrackSchemeViewAction, NEW_TRACKSCHEME_VIEW_KEYS );
 		globalAppActions.namedAction( editTagSetsAction, TAGSETS_DIALOG_KEYS );
 
-		final PreferencesDialog settings = new PreferencesDialog( null );
+		final PreferencesDialog settings = new PreferencesDialog( null, keymap, new String[] { "mastodon" } );
 		settings.addPage( new TrackSchemeStyleSettingsPage( "TrackScheme Styles", trackSchemeStyleManager ) );
 		settings.addPage( new RenderSettingsConfigPage( "BDV Render Settings", renderSettingsManager ) );
 		settings.addPage( new KeymapSettingsPage( "Keymap", keymapManager ) );

--- a/src/main/java/org/mastodon/revised/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/WindowManager.java
@@ -134,6 +134,7 @@ public class WindowManager
 		this.appModel = appModel;
 		if ( appModel == null )
 		{
+			tagSetDialog.dispose();
 			tagSetDialog = null;
 			updateEnabledActions();
 			return;
@@ -143,7 +144,8 @@ public class WindowManager
 		UndoActions.install( appModel.getAppActions(), model );
 		SelectionActions.install( appModel.getAppActions(), model.getGraph(), model.getGraph().getLock(), model.getGraph(), appModel.getSelectionModel(), model );
 
-		tagSetDialog = new TagSetDialog( null, model.getTagSetModel(), model );
+		final Keymap keymap = keymapManager.getForwardDefaultKeymap();
+		tagSetDialog = new TagSetDialog( null, model.getTagSetModel(), model, keymap, new String[] { "mastodon" } );
 		updateEnabledActions();
 	}
 


### PR DESCRIPTION
To properly close the view, we send it a` WINDOW_CLOSING` event.
This way, the listeners of the` JFrame` are called and the closing happens gracefully within Mastodon.