### PR TITLE
Use parent application Context when launched from said app.

### DIFF
--- a/src/main/java/org/mastodon/revised/mamut/Mastodon.java
+++ b/src/main/java/org/mastodon/revised/mamut/Mastodon.java
@@ -1,6 +1,5 @@
 package org.mastodon.revised.mamut;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Locale;
@@ -11,12 +10,13 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
 import org.scijava.command.Command;
+import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Plugin;
 
 import mpicbg.spim.data.SpimDataException;
 
 @Plugin( type = Command.class, menuPath = "Plugins>Mastodon (preview)" )
-public class Mastodon implements Command
+public class Mastodon extends ContextCommand
 {
 	private WindowManager windowManager;
 
@@ -26,7 +26,7 @@ public class Mastodon implements Command
 	public void run()
 	{
 		System.setProperty( "apple.laf.useScreenMenuBar", "true" );
-		windowManager = new WindowManager();
+		windowManager = new WindowManager( getContext() );
 		mainWindow = new MainWindow( windowManager );
 		mainWindow.setVisible( true );
 	}

--- a/src/main/java/org/mastodon/revised/mamut/Mastodon.java
+++ b/src/main/java/org/mastodon/revised/mamut/Mastodon.java
@@ -9,6 +9,7 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 
+import org.scijava.Context;
 import org.scijava.command.Command;
 import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Plugin;
@@ -37,6 +38,7 @@ public class Mastodon extends ContextCommand
 		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
 
 		final Mastodon mastodon = new Mastodon();
+		new Context().inject( mastodon );
 		mastodon.run();
 		mastodon.mainWindow.setDefaultCloseOperation( WindowConstants.EXIT_ON_CLOSE );
 

--- a/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
@@ -21,7 +21,6 @@ import org.mastodon.revised.ui.util.FileChooser;
 import org.mastodon.revised.ui.util.FileChooser.SelectionMode;
 import org.mastodon.revised.ui.util.XmlFileFilter;
 import org.mastodon.revised.util.ToggleDialogAction;
-import org.scijava.Context;
 import org.scijava.ui.behaviour.KeyPressedManager;
 import org.scijava.ui.behaviour.util.AbstractNamedAction;
 import org.scijava.ui.behaviour.util.Actions;
@@ -68,12 +67,9 @@ public class ProjectManager
 
 	private final AbstractNamedAction exportMamutAction;
 
-	private final Context context;
-
-	public ProjectManager( final WindowManager windowManager, final Context context )
+	public ProjectManager( final WindowManager windowManager )
 	{
 		this.windowManager = windowManager;
-		this.context = context;
 
 		tgmmImportDialog = new TgmmImportDialog( null );
 
@@ -273,7 +269,7 @@ public class ProjectManager
 
 		windowManager.setAppModel( appModel );
 
-		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
+		final MamutFeatureComputerService featureComputerService = windowManager.getContext().getService( MamutFeatureComputerService.class );
 		final JFrame owner = null; // TODO
 		final Dialog featureComputationDialog = new FeatureAndTagDialog( owner, model, featureComputerService );
 		featureComputationDialog.setSize( 400, 400 );

--- a/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/ProjectManager.java
@@ -68,9 +68,12 @@ public class ProjectManager
 
 	private final AbstractNamedAction exportMamutAction;
 
-	public ProjectManager( final WindowManager windowManager )
+	private final Context context;
+
+	public ProjectManager( final WindowManager windowManager, final Context context )
 	{
 		this.windowManager = windowManager;
+		this.context = context;
 
 		tgmmImportDialog = new TgmmImportDialog( null );
 
@@ -270,11 +273,6 @@ public class ProjectManager
 
 		windowManager.setAppModel( appModel );
 
-		/*
-		 * TODO FIXE Ugly hack to get proper service instantiation. Fix it by
-		 * proposing a proper Command decoupled from the GUI.
-		 */
-		final Context context = new Context();
 		final MamutFeatureComputerService featureComputerService = context.getService( MamutFeatureComputerService.class );
 		final JFrame owner = null; // TODO
 		final Dialog featureComputationDialog = new FeatureAndTagDialog( owner, model, featureComputerService );

--- a/src/main/java/org/mastodon/revised/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/WindowManager.java
@@ -23,6 +23,7 @@ import org.mastodon.revised.ui.keymap.KeymapManager;
 import org.mastodon.revised.ui.keymap.KeymapSettingsPage;
 import org.mastodon.revised.util.ToggleDialogAction;
 import org.mastodon.views.context.ContextProvider;
+import org.scijava.Context;
 import org.scijava.ui.behaviour.KeyPressedManager;
 import org.scijava.ui.behaviour.io.InputTriggerDescription;
 import org.scijava.ui.behaviour.io.InputTriggerDescriptionsBuilder;
@@ -84,6 +85,12 @@ public class WindowManager
 
 	public WindowManager()
 	{
+		this( null );
+	}
+
+	public WindowManager(final Context ct )
+	{
+		final Context context = ct == null ? new Context() : ct;
 		keyPressedManager = new KeyPressedManager();
 		trackSchemeStyleManager = new TrackSchemeStyleManager();
 		renderSettingsManager = new RenderSettingsManager();
@@ -99,7 +106,7 @@ public class WindowManager
 				appModel.getAppActions().updateKeyConfig( keymap.getConfig() );
 		} );
 
-		projectManager = new ProjectManager( this );
+		projectManager = new ProjectManager( this, context );
 		projectManager.install( globalAppActions );
 
 		newBdvViewAction = new RunnableAction( NEW_BDV_VIEW, this::createBigDataViewer );

--- a/src/main/java/org/mastodon/revised/mamut/WindowManager.java
+++ b/src/main/java/org/mastodon/revised/mamut/WindowManager.java
@@ -46,6 +46,8 @@ public class WindowManager
 	static final String[] PREFERENCES_DIALOG_KEYS = new String[] { "meta COMMA", "control COMMA" };
 	static final String[] TAGSETS_DIALOG_KEYS = new String[] { "not mapped" };
 
+	private final Context context;
+
 	/**
 	 * All currently open BigDataViewer windows.
 	 */
@@ -83,14 +85,10 @@ public class WindowManager
 
 	final ProjectManager projectManager;
 
-	public WindowManager()
+	public WindowManager( final Context context )
 	{
-		this( null );
-	}
+		this.context = context;
 
-	public WindowManager(final Context ct )
-	{
-		final Context context = ct == null ? new Context() : ct;
 		keyPressedManager = new KeyPressedManager();
 		trackSchemeStyleManager = new TrackSchemeStyleManager();
 		renderSettingsManager = new RenderSettingsManager();
@@ -106,7 +104,7 @@ public class WindowManager
 				appModel.getAppActions().updateKeyConfig( keymap.getConfig() );
 		} );
 
-		projectManager = new ProjectManager( this, context );
+		projectManager = new ProjectManager( this );
 		projectManager.install( globalAppActions );
 
 		newBdvViewAction = new RunnableAction( NEW_BDV_VIEW, this::createBigDataViewer );
@@ -280,6 +278,11 @@ public class WindowManager
 	Actions getGlobalAppActions()
 	{
 		return globalAppActions;
+	}
+
+	public Context getContext()
+	{
+		return context;
 	}
 
 	// TODO: move somewhere else. make bdvWindows, tsWindows accessible.


### PR DESCRIPTION
If Mastodon is launched via its `Command` interface, for instance when it is launched from the ImageJ2 plugins menu, it MUST get the Context of the parent app.

Before this commit, Mastodon was creating its own `Context` instance which caused a bug noticed by @tpietzsch:

"When run from Fiji, Mastodon somehow manages to disable the Command-Q shortcut for quitting (Fiji). This happens after a project is opened. Before (when only the MainWindow is open), it still works."

Actually quitting from Fiji after opening a project raised an exception caused indirectly by the two Context instances conflicting (details unknown, I did not investigate).

This commit fixes this issue by getting the Context instance from the command and passing it to where it is needed. If no Context is provided to the WindowManager, then it is allowed to create one.