### PR TITLE
Set enabled flag of selection menu items from EDT thread.

### DIFF
--- a/src/main/java/org/mastodon/revised/ui/SelectionActions.java
+++ b/src/main/java/org/mastodon/revised/ui/SelectionActions.java
@@ -3,6 +3,8 @@ package org.mastodon.revised.ui;
 import java.awt.event.ActionEvent;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import javax.swing.SwingUtilities;
+
 import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefSet;
 import org.mastodon.graph.Edge;
@@ -146,8 +148,9 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 		DeleteSelectionAction( final String name )
 		{
 			super( name );
-			setEnabled( !selection.isEmpty() );
-			selection.listeners().add( () -> setEnabled( !selection.isEmpty() ) );
+			SwingUtilities.invokeLater( () -> setEnabled( !selection.isEmpty() ) );
+			selection.listeners().add( () -> SwingUtilities.invokeLater(
+					() -> setEnabled( !selection.isEmpty() ) ) );
 		}
 
 		@Override
@@ -191,8 +194,9 @@ public class SelectionActions< V extends Vertex< E >, E extends Edge< V > >
 		{
 			super( name );
 			this.directivity = directivity;
-			setEnabled( !selection.isEmpty() );
-			selection.listeners().add( () -> setEnabled( !selection.isEmpty() ) );
+			SwingUtilities.invokeLater( () -> setEnabled( !selection.isEmpty() ) );
+			selection.listeners().add( () -> SwingUtilities.invokeLater(
+					() -> setEnabled( !selection.isEmpty() ) ) );
 		}
 
 		@Override


### PR DESCRIPTION
Ok, so this is downstream a bug that caused Mastodon to freeze completely when using the semi-automatic tracker.

When the semi-automatic tracker is launched from a 'normal' thread, it completely froze Mastodon. The reason is that the tracker changes the selection model when a spot is created or discovered. The selection model listeners in the `SelectionActions` class that toggle whether some menu items (related
to selection) are enabled or not.
Since the listeners were not triggered from the EDT, this caused the freeze.

To fix this problem, this commit simply ensures that the `setEnabled` method from related `Action` is called from the EDT with `SwingUtilities.involkeLater()`.