### PR TITLE
FIX: Mamut XML exporter:

### DIFF
--- a/src/main/java/org/mastodon/revised/model/mamut/trackmate/MamutExporter.java
+++ b/src/main/java/org/mastodon/revised/model/mamut/trackmate/MamutExporter.java
@@ -475,13 +475,12 @@ public class MamutExporter
 		}
 
 		final SpatioTemporalIndex< Spot > spots = model.getSpatioTemporalIndex();
-		for ( final TimePoint tp : tps )
+		for ( int i = 0; i < tps.size(); ++i )
 		{
-
 			final Element frameSpotsElement = new Element( SPOT_FRAME_COLLECTION_TAG );
-			frameSpotsElement.setAttribute( FRAME_ATTRIBUTE, tp.getName() );
+			frameSpotsElement.setAttribute( FRAME_ATTRIBUTE, tps.get(i).getName() );
 
-			for ( final Spot spot : spots.getSpatialIndex( tp.getId() ) )
+			for ( final Spot spot : spots.getSpatialIndex( i ) )
 			{
 				final Element spotElement = spotToXml( spot );
 				frameSpotsElement.addContent( spotElement );


### PR DESCRIPTION
deals with issue #66 

When exporting into Mamut format:
- time points are fetched from the underlying data (e.g. dataset.xml),
  and they order themselves in a, not necessarily continuous, sequence
  that may start, not necessarily, from non-zero time value
- Mastodon internal data, however, store time points zero-based sequentially
- both series must be of the same length
- the fix just iterates them in synchrony