### PR TITLE
Edit Tags in the menu and with a key listener.

### DIFF
--- a/src/main/java/org/mastodon/revised/mamut/MamutMenuBuilder.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutMenuBuilder.java
@@ -81,6 +81,11 @@ public class MamutMenuBuilder extends ViewMenuBuilder
 		return ViewMenuBuilder.menu( "Coloring", handle );
 	}
 
+	public static MenuItem tagSetMenu( final JMenuHandle handle )
+	{
+		return ViewMenuBuilder.menu( "Tags", handle );
+	}
+
 	public static MenuItem editMenu( final MenuItem... items )
 	{
 		return ViewMenuBuilder.menu( "Edit", items );

--- a/src/main/java/org/mastodon/revised/mamut/MamutView.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutView.java
@@ -6,9 +6,12 @@ import org.mastodon.app.ui.ViewMenuBuilder.JMenuHandle;
 import org.mastodon.feature.FeatureModel;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Vertex;
+import org.mastodon.model.SelectionModel;
 import org.mastodon.revised.model.mamut.Link;
+import org.mastodon.revised.model.mamut.Model;
 import org.mastodon.revised.model.mamut.Spot;
 import org.mastodon.revised.model.tag.TagSetModel;
+import org.mastodon.revised.ui.TagSetMenu;
 import org.mastodon.revised.ui.coloring.ColoringMenu;
 import org.mastodon.revised.ui.coloring.ColoringModel;
 import org.mastodon.revised.ui.coloring.GraphColorGeneratorAdapter;
@@ -69,5 +72,17 @@ public class MamutView< VG extends ViewGraph< Spot, Link, V, E >, V extends Vert
 			refresh.run();
 		};
 		coloringModel.listeners().add( coloringChangedListener );
+	}
+
+	protected void registerTagSetMenu(
+			final JMenuHandle menuHandle,
+			final Runnable refresh )
+	{
+		final SelectionModel< Spot, Link > selectionModel = appModel.getSelectionModel();
+		final Model model = appModel.getModel();
+		final TagSetModel< Spot, Link > tagSetModel = model.getTagSetModel();
+		final TagSetMenu< Spot, Link > tagSetMenu = new TagSetMenu< >( menuHandle.getMenu(), tagSetModel, selectionModel, model );
+		tagSetModel.listeners().add( tagSetMenu );
+		onClose( () -> tagSetModel.listeners().remove( tagSetMenu ) );
 	}
 }

--- a/src/main/java/org/mastodon/revised/mamut/MamutView.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutView.java
@@ -81,7 +81,7 @@ public class MamutView< VG extends ViewGraph< Spot, Link, V, E >, V extends Vert
 		final SelectionModel< Spot, Link > selectionModel = appModel.getSelectionModel();
 		final Model model = appModel.getModel();
 		final TagSetModel< Spot, Link > tagSetModel = model.getTagSetModel();
-		final TagSetMenu< Spot, Link > tagSetMenu = new TagSetMenu< >( menuHandle.getMenu(), tagSetModel, selectionModel, model );
+		final TagSetMenu< Spot, Link > tagSetMenu = new TagSetMenu< >( menuHandle.getMenu(), tagSetModel, selectionModel, model.getGraph().getLock(), model );
 		tagSetModel.listeners().add( tagSetMenu );
 		onClose( () -> tagSetModel.listeners().remove( tagSetMenu ) );
 	}

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewBdv.java
@@ -5,6 +5,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.colorMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.editMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.fileMenu;
+import static org.mastodon.revised.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.viewMenu;
 
 import javax.swing.ActionMap;
@@ -81,6 +82,7 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		final ActionMap actionMap = frame.getKeybindings().getConcatenatedActionMap();
 
 		final JMenuHandle menuHandle = new JMenuHandle();
+		final JMenuHandle tagSetMenuHandle = new JMenuHandle();
 		MainWindow.addMenus( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
 				fileMenu(
@@ -100,7 +102,9 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 						item( SelectionActions.DELETE_SELECTION ),
 						item( SelectionActions.SELECT_WHOLE_TRACK ),
 						item( SelectionActions.SELECT_TRACK_DOWNWARD ),
-						item( SelectionActions.SELECT_TRACK_UPWARD )
+						item( SelectionActions.SELECT_TRACK_UPWARD ),
+						separator(),
+						tagSetMenu( tagSetMenuHandle )
 				),
 				ViewMenuBuilder.menu( "Settings",
 						item( BigDataViewerActionsMamut.BRIGHTNESS_SETTINGS ),
@@ -132,6 +136,8 @@ public class MamutViewBdv extends MamutView< OverlayGraphWrapper< Spot, Link >, 
 		final ModelGraph modelGraph = model.getGraph();
 
 		registerColoring( coloring, menuHandle, () -> viewer.getDisplay().repaint() );
+		registerTagSetMenu( tagSetMenuHandle, () -> viewer.getDisplay().repaint() );
+
 		highlightModel.listeners().add( () -> viewer.getDisplay().repaint() );
 		focusModel.listeners().add( () -> viewer.getDisplay().repaint() );
 		modelGraph.addGraphChangeListener( () -> viewer.getDisplay().repaint() );

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
@@ -4,6 +4,7 @@ import static org.mastodon.app.ui.ViewMenuBuilder.item;
 import static org.mastodon.app.ui.ViewMenuBuilder.separator;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.colorMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.editMenu;
+import static org.mastodon.revised.mamut.MamutMenuBuilder.tagSetMenu;
 import static org.mastodon.revised.mamut.MamutMenuBuilder.viewMenu;
 
 import javax.swing.ActionMap;
@@ -108,6 +109,7 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 		final ActionMap actionMap = frame.getKeybindings().getConcatenatedActionMap();
 
 		final JMenuHandle coloringMenuHandle = new JMenuHandle();
+		final JMenuHandle tagSetMenuHandle = new JMenuHandle();
 
 		MainWindow.addMenus( menu, actionMap );
 		MamutMenuBuilder.build( menu, actionMap,
@@ -135,12 +137,16 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 						item( TrackSchemeNavigationActions.NAVIGATE_LEFT ),
 						item( TrackSchemeNavigationActions.NAVIGATE_RIGHT ),
 						separator(),
-						item( EditFocusVertexLabelAction.EDIT_FOCUS_LABEL )
+						item( EditFocusVertexLabelAction.EDIT_FOCUS_LABEL ),
+						tagSetMenu( tagSetMenuHandle )
 				)
 		);
 		appModel.getPlugins().addMenus( menu );
 
 		registerColoring( coloring, coloringMenuHandle,
+				() -> frame.getTrackschemePanel().entitiesAttributesChanged() );
+
+		registerTagSetMenu( tagSetMenuHandle,
 				() -> frame.getTrackschemePanel().entitiesAttributesChanged() );
 
 		frame.getTrackschemePanel().repaint();

--- a/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
+++ b/src/main/java/org/mastodon/revised/mamut/MamutViewTrackScheme.java
@@ -97,7 +97,7 @@ public class MamutViewTrackScheme extends MamutView< TrackSchemeGraph< Spot, Lin
 		EditFocusVertexLabelAction.install( viewActions, frame.getTrackschemePanel(), focusModel, model );
 		FocusActions.install( viewActions, viewGraph, viewGraph.getLock(), navigateFocusModel, selectionModel );
 		TrackSchemeZoom.install( viewBehaviours, frame.getTrackschemePanel() );
-		EditTagActions.install( viewActions, frame.getKeybindings(), frame.getTriggerbindings(), model.getTagSetModel(), appModel.getSelectionModel(), frame.getTrackschemePanel(), frame.getTrackschemePanel().getDisplay(), model );
+		EditTagActions.install( viewActions, frame.getKeybindings(), frame.getTriggerbindings(), model.getTagSetModel(), appModel.getSelectionModel(), viewGraph.getLock(), frame.getTrackschemePanel(), frame.getTrackschemePanel().getDisplay(), model );
 		viewActions.runnableAction( () -> System.out.println( model.getTagSetModel() ), "output tags", "U" ); // DEBUG TODO: REMOVE
 
 		// TODO Let the user choose between the two selection/focus modes.

--- a/src/main/java/org/mastodon/revised/ui/EditTagActions.java
+++ b/src/main/java/org/mastodon/revised/ui/EditTagActions.java
@@ -28,6 +28,7 @@ import org.mastodon.revised.model.tag.TagSetStructure.Tag;
 import org.mastodon.revised.model.tag.TagSetStructure.TagSet;
 import org.mastodon.revised.ui.keymap.CommandDescriptionProvider;
 import org.mastodon.revised.ui.keymap.CommandDescriptions;
+import org.mastodon.revised.ui.util.NumberListeners;
 import org.mastodon.undo.UndoPointMarker;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.behaviour.InputTriggerMap;
@@ -154,28 +155,44 @@ public class EditTagActions< V extends Vertex< E >, E extends Edge< V > >
 		inputMap.put( abortKey, "abort tags" );
 		actionMap.put( "abort tags", abortAction );
 
+		// Do we have more than 9 tagsets?
+		final boolean manyTagSets = tagModel.getTagSetStructure().getTagSets().size() > 9;
+
 		// Prepare tag map.
-		int i = 1;
-		for ( final TagSet tagSet : tagModel.getTagSetStructure().getTagSets() )
+
+		if ( manyTagSets )
 		{
-			final String actionName = "select tag " + i;
-			final KeyStroke tagKeyStroke = KeyStroke.getKeyStroke( ( char ) ( '0' + i ) );
-			final AbstractAction action = new AbstractAction( actionName )
-			{
-				@Override
-				public void actionPerformed( final ActionEvent e )
+			NumberListeners.positiveIntegerListener( actionMap, inputMap, ( n ) -> {
+				final int i = ( int ) n;
+				if ( i > 0 && i <= tagModel.getTagSetStructure().getTagSets().size() )
 				{
-					selectTagSet( tagSet );
+					selectTagSet( tagModel.getTagSetStructure().getTagSets().get( i - 1 ) );
 				}
-
-				private static final long serialVersionUID = 1L;
-			};
-
-			inputMap.put( tagKeyStroke, actionName );
-			actionMap.put( actionName, action );
-			i++;
+			} );
 		}
+		else
+		{
+			int i = 1;
+			for ( final TagSet tagSet : tagModel.getTagSetStructure().getTagSets() )
+			{
+				final String actionName = "select tag " + i;
+				final KeyStroke tagKeyStroke = KeyStroke.getKeyStroke( ( char ) ( '0' + i ) );
+				final AbstractAction action = new AbstractAction( actionName )
+				{
+					@Override
+					public void actionPerformed( final ActionEvent e )
+					{
+						selectTagSet( tagSet );
+					}
 
+					private static final long serialVersionUID = 1L;
+				};
+
+				inputMap.put( tagKeyStroke, actionName );
+				actionMap.put( actionName, action );
+				i++;
+			}
+		}
 		actionBindings.addActionMap( PICK_TAGS_MAP, actionMap );
 		actionBindings.addInputMap( PICK_TAGS_MAP, inputMap, "all" );
 		behaviourBindings.addInputTriggerMap( PICK_TAGS_MAP, triggerMap, "all" );
@@ -253,25 +270,43 @@ public class EditTagActions< V extends Vertex< E >, E extends Edge< V > >
 		inputMap.put( clearAllKey, "clear all labels" );
 		actionMap.put( "clear all labels", clearAllAction );
 
-		int i = 1;
-		for ( final Tag tag : tagSet.getTags() )
+		// Prepare tag map.
+
+		// Do we have more than 9 tags?
+		final boolean manyTags = tagSet.getTags().size() > 9;
+		if ( manyTags )
 		{
-			final String actionName = "select label " + i;
-			final KeyStroke takKeyStroke = KeyStroke.getKeyStroke( ( char ) ( '0' + i ) );
-			final AbstractAction action = new AbstractAction( actionName )
-			{
-				@Override
-				public void actionPerformed( final ActionEvent e )
+			panel.requestFocusInWindow();
+			NumberListeners.positiveIntegerListener( actionMap, inputMap, ( n ) -> {
+				final int i = ( int ) n;
+				if ( i > 0 && i <= tagSet.getTags().size() )
 				{
-					selectTag( tag );
+					selectTag( tagSet.getTags().get( i - 1 ) );
 				}
+			} );
+		}
+		else
+		{
+			int i = 1;
+			for ( final Tag tag : tagSet.getTags() )
+			{
+				final String actionName = "select label " + i;
+				final KeyStroke takKeyStroke = KeyStroke.getKeyStroke( ( char ) ( '0' + i ) );
+				final AbstractAction action = new AbstractAction( actionName )
+				{
+					@Override
+					public void actionPerformed( final ActionEvent e )
+					{
+						selectTag( tag );
+					}
 
-				private static final long serialVersionUID = 1L;
-			};
+					private static final long serialVersionUID = 1L;
+				};
 
-			inputMap.put( takKeyStroke, actionName );
-			actionMap.put( actionName, action );
-			i++;
+				inputMap.put( takKeyStroke, actionName );
+				actionMap.put( actionName, action );
+				i++;
+			}
 		}
 
 		actionBindings.addActionMap( PICK_TAGS_MAP, actionMap );

--- a/src/main/java/org/mastodon/revised/ui/TagSetMenu.java
+++ b/src/main/java/org/mastodon/revised/ui/TagSetMenu.java
@@ -1,0 +1,150 @@
+package org.mastodon.revised.ui;
+
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JSeparator;
+
+import org.mastodon.graph.Edge;
+import org.mastodon.graph.Vertex;
+import org.mastodon.model.SelectionModel;
+import org.mastodon.revised.model.tag.ObjTagMap;
+import org.mastodon.revised.model.tag.TagSetModel;
+import org.mastodon.revised.model.tag.TagSetStructure;
+import org.mastodon.revised.model.tag.TagSetStructure.Tag;
+import org.mastodon.revised.model.tag.TagSetStructure.TagSet;
+import org.mastodon.revised.util.ColorIcon;
+import org.mastodon.revised.util.MnemonicsAssigner;
+import org.mastodon.undo.UndoPointMarker;
+import org.scijava.ui.behaviour.util.AbstractNamedAction;
+
+public class TagSetMenu< V extends Vertex< E >, E extends Edge< V > > implements TagSetModel.TagSetModelListener
+{
+
+	private final JMenu menu;
+
+	private final TagSetModel< V, E > tagSetModel;
+
+	private final SelectionModel< V, E > selectionModel;
+
+	private final UndoPointMarker undo;
+
+	public TagSetMenu( final JMenu menu, final TagSetModel< V, E > tagSetModel, final SelectionModel< V, E > selectionModel, final UndoPointMarker undo )
+	{
+		this.menu = menu;
+		this.tagSetModel = tagSetModel;
+		this.selectionModel = selectionModel;
+		this.undo = undo;
+		rebuild();
+	}
+
+	public void rebuild()
+	{
+		menu.removeAll();
+		final MnemonicsAssigner menuMnemo = new MnemonicsAssigner();
+
+		final TagSetStructure tagSetStructure = tagSetModel.getTagSetStructure();
+		final List< TagSetStructure.TagSet > tagSets = tagSetStructure.getTagSets();
+		for ( final TagSetStructure.TagSet ts : tagSets )
+		{
+			final JMenu tsMenu = new JMenu( ts.getName() );
+			menuMnemo.add( tsMenu );
+
+			final MnemonicsAssigner subMenuMnemo = new MnemonicsAssigner();
+			for ( final Tag tag : ts.getTags() )
+			{
+				final JMenuItem menuItem = new JMenuItem( new SetTagAction<>( tagSetModel, ts, tag, selectionModel, undo ) );
+				subMenuMnemo.add( menuItem );
+				tsMenu.add( menuItem );
+			}
+
+			tsMenu.add( new JSeparator() );
+
+			final JMenuItem clearTagMenuItem = new JMenuItem( new ClearTagAction<>( tagSetModel, ts, selectionModel, undo ) );
+			subMenuMnemo.add( clearTagMenuItem );
+			tsMenu.add( clearTagMenuItem );
+			menu.add( tsMenu );
+			subMenuMnemo.assignMnenonics();
+		}
+		menuMnemo.assignMnenonics();
+	}
+
+	@Override
+	public void tagSetStructureChanged()
+	{
+		rebuild();
+	}
+
+	private static class SetTagAction< V extends Vertex< E >, E extends Edge< V > > extends AbstractAction
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final Tag tag;
+
+		private final TagSet tagSet;
+
+		private final SelectionModel< V, E > selectionModel;
+
+		private final UndoPointMarker undo;
+
+		private final TagSetModel< V, E > tagSetModel;
+
+		public SetTagAction( final TagSetModel< V, E > tagSetModel, final TagSet tagSet, final Tag tag, final SelectionModel< V, E > selectionModel, final UndoPointMarker undo )
+		{
+			super( tag.label(), new ColorIcon( new Color( tag.color(), true ) ) );
+			this.tagSetModel = tagSetModel;
+			this.tagSet = tagSet;
+			this.tag = tag;
+			this.selectionModel = selectionModel;
+			this.undo = undo;
+		}
+
+		@Override
+		public void actionPerformed( final ActionEvent evtt )
+		{
+			final ObjTagMap< V, Tag > vertexTags = tagSetModel.getVertexTags().tags( tagSet );
+			final ObjTagMap< E, Tag > edgeTags = tagSetModel.getEdgeTags().tags( tagSet );
+			selectionModel.getSelectedVertices().forEach( v -> vertexTags.set( v, tag ) );
+			selectionModel.getSelectedEdges().forEach( e -> edgeTags.set( e, tag ) );
+			undo.setUndoPoint();
+		}
+	}
+
+	private static class ClearTagAction< V extends Vertex< E >, E extends Edge< V > > extends AbstractNamedAction
+	{
+
+		private static final long serialVersionUID = 1L;
+
+		private final TagSet tagSet;
+
+		private final SelectionModel< V, E > selectionModel;
+
+		private final UndoPointMarker undo;
+
+		private final TagSetModel< V, E > tagSetModel;
+
+		public ClearTagAction( final TagSetModel< V, E > tagSetModel, final TagSet tagSet, final SelectionModel< V, E > selectionModel, final UndoPointMarker undo )
+		{
+			super( "Clear tags for " + tagSet.getName() );
+			this.tagSetModel = tagSetModel;
+			this.tagSet = tagSet;
+			this.selectionModel = selectionModel;
+			this.undo = undo;
+		}
+
+		@Override
+		public void actionPerformed( final ActionEvent evtt )
+		{
+			final ObjTagMap< V, Tag > vertexTags = tagSetModel.getVertexTags().tags( tagSet );
+			final ObjTagMap< E, Tag > edgeTags = tagSetModel.getEdgeTags().tags( tagSet );
+			selectionModel.getSelectedVertices().forEach( v -> vertexTags.set( v, null ) );
+			selectionModel.getSelectedEdges().forEach( e -> edgeTags.set( e, null ) );
+			undo.setUndoPoint();
+		}
+	}
+}

--- a/src/main/java/org/mastodon/revised/ui/TagSetMenu.java
+++ b/src/main/java/org/mastodon/revised/ui/TagSetMenu.java
@@ -72,9 +72,9 @@ public class TagSetMenu< V extends Vertex< E >, E extends Edge< V > > implements
 			subMenuMnemo.add( clearTagMenuItem );
 			tsMenu.add( clearTagMenuItem );
 			menu.add( tsMenu );
-			subMenuMnemo.assignMnenonics();
+			subMenuMnemo.assignMnemonics();
 		}
-		menuMnemo.assignMnenonics();
+		menuMnemo.assignMnemonics();
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/revised/ui/util/NumberListeners.java
+++ b/src/main/java/org/mastodon/revised/ui/util/NumberListeners.java
@@ -1,0 +1,242 @@
+package org.mastodon.revised.ui.util;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleConsumer;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.KeyStroke;
+
+/**
+ * Utility to register number listeners on components.
+ * <p>
+ * The listeners of this class are {@link KeyListener}s that listen to the user
+ * typing a number, building a string representation as he types, then
+ * converting the string to a double after a wait time. So that if the user
+ * types
+ *
+ * <pre>
+ * '4', '9', '.', '3,
+ * </pre>
+ *
+ * then wait for 1 second without typing anything, the component will by
+ * notified with the number 49.3. Pressing space or enter commits the number
+ * immediately without waiting.
+ * <p>
+ * Different methods allow to register a listener that can listen to positive
+ * only double or integer numbers. They return the actual {@link KeyListener}
+ * instance that fuel this, so that consumers can de-register them after use.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class NumberListeners
+{
+
+	/**
+	 * How much time we wait before committing a number.
+	 */
+	private static final long WAIT_DELAY = 1; // s
+
+	public static void doubleListener( final ActionMap actionMap, final InputMap inputMap, final DoubleConsumer notify )
+	{
+		new NumberListener( actionMap, inputMap, notify, true, true );
+	}
+
+	public static void positiveDoubleListener( final ActionMap actionMap, final InputMap inputMap, final DoubleConsumer notify )
+	{
+		new NumberListener( actionMap, inputMap, notify, true, false );
+	}
+
+	public static void integerListener( final ActionMap actionMap, final InputMap inputMap, final DoubleConsumer notify )
+	{
+		new NumberListener( actionMap, inputMap, notify, false, true );
+	}
+
+	public static void positiveIntegerListener( final ActionMap actionMap, final InputMap inputMap, final DoubleConsumer notify )
+	{
+		new NumberListener( actionMap, inputMap, notify, false, false );
+	}
+
+	private static class NumberListener
+	{
+
+		private String strNumber = "";
+
+		private ScheduledExecutorService ex;
+
+		private ScheduledFuture< ? > future;
+
+		private final ActionMap actionMap;
+
+		private final InputMap inputMap;
+
+		private boolean dotAdded = false;
+
+		private final DoubleConsumer notify;
+
+		private final boolean acceptDot;
+
+		private final boolean acceptSign;
+
+		public NumberListener(
+				final ActionMap actionMap,
+				final InputMap inputMap,
+				final DoubleConsumer notify,
+				final boolean acceptDot,
+				final boolean acceptSign )
+		{
+			this.actionMap = actionMap;
+			this.inputMap = inputMap;
+			this.notify = notify;
+			this.acceptDot = acceptDot;
+			this.acceptSign = acceptSign;
+			setup();
+		}
+
+		private final Runnable command = new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				// Convert to double.
+				try
+				{
+					final double number = Double.parseDouble( strNumber );
+					notify.accept( number );
+				}
+				catch ( final NumberFormatException nfe )
+				{}
+				// Reset
+				ex = null;
+				strNumber = "";
+				dotAdded = false;
+			}
+		};
+
+		private void setup()
+		{
+			// Digit keys.
+			for ( int i = 1; i < 10; i++ )
+			{
+				final String actionName = "digit " + i;
+				final int digit = i;
+				final KeyStroke digitKey = KeyStroke.getKeyStroke( ( char ) ( '0' + i ) );
+				final Action digitAction = new AbstractAction( actionName )
+				{
+					@Override
+					public void actionPerformed( final ActionEvent e )
+					{
+						restartTimer();
+						strNumber += "" + digit;
+					}
+
+					private static final long serialVersionUID = 1L;
+				};
+				inputMap.put( digitKey, actionName );
+				actionMap.put( actionName, digitAction );
+			}
+
+			// Dot key.
+			if ( acceptDot )
+			{
+				final String actionName = "dot";
+				final KeyStroke dotKey = KeyStroke.getKeyStroke( '.' );
+				final Action dotAction = new AbstractAction( "dot" )
+				{
+					@Override
+					public void actionPerformed( final ActionEvent e )
+					{
+						if ( dotAdded )
+							return;
+
+						restartTimer();
+						dotAdded = true;
+						strNumber += ".";
+					}
+
+					private static final long serialVersionUID = 1L;
+				};
+				inputMap.put( dotKey, actionName );
+				actionMap.put( actionName, dotAction );
+			}
+
+			// Sign keys.
+			if ( acceptSign )
+			{
+				final char[] signChars = new char[] { '+', '-' };
+				for ( final char signChar : signChars )
+				{
+					final String actionName = "sign " + signChar;
+					final KeyStroke signKey = KeyStroke.getKeyStroke( signChar );
+					final Action signAction = new AbstractAction( "sign " + signChar )
+					{
+						@Override
+						public void actionPerformed( final ActionEvent e )
+						{
+							// Only accept sign as a first character.
+							if ( strNumber.length() > 1 )
+								return;
+
+							restartTimer();
+							strNumber += "" + signChar;
+						}
+
+						private static final long serialVersionUID = 1L;
+					};
+
+					inputMap.put( signKey, actionName );
+					actionMap.put( actionName, signAction );
+				}
+			}
+
+			// Commit keys.
+			final int[] commitKeyCodes = new int[] {
+					KeyEvent.VK_ENTER,
+					KeyEvent.VK_SPACE,
+					KeyEvent.VK_TAB
+			};
+			for ( final int commitKeyCode : commitKeyCodes )
+			{
+				final String actionName = "commit with " + KeyEvent.getKeyText( commitKeyCode );
+				final KeyStroke commitKey = KeyStroke.getKeyStroke( commitKeyCode, 0 );
+				final Action commitAction = new AbstractAction( actionName )
+				{
+					@Override
+					public void actionPerformed( final ActionEvent e )
+					{
+						command.run();
+					}
+
+					private static final long serialVersionUID = 1L;
+				};
+
+				inputMap.put( commitKey, actionName );
+				actionMap.put( actionName, commitAction );
+			}
+		}
+
+		private void restartTimer()
+		{
+			if ( ex == null )
+			{
+				// Create new waiting line
+				ex = Executors.newSingleThreadScheduledExecutor();
+				future = ex.schedule( command, WAIT_DELAY, TimeUnit.SECONDS );
+			}
+			else
+			{
+				// Reset waiting line
+				future.cancel( false );
+				future = ex.schedule( command, WAIT_DELAY, TimeUnit.SECONDS );
+			}
+		}
+	}
+}

--- a/src/main/java/org/mastodon/revised/util/GroupStrings.java
+++ b/src/main/java/org/mastodon/revised/util/GroupStrings.java
@@ -15,24 +15,24 @@ import java.util.Set;
  * words.
  * <p>
  * For instance, the 3 strings:
- * 
+ *
  * <pre>
- * - "Save Project"
- * - "Import TGMM tracks"
- * - "Import Simi BioCell tracks"
+ * -"Save Project"
+ * -"Import TGMM tracks"
+ * -"Import Simi BioCell tracks"
  * </pre>
  *
  * will be grouped in 2 groups:
- * 
+ *
  * <pre>
- * - "Save Project"
- * - "Import"
- * 	+ "TGMM tracks"
- * 	+ "Simi BioCell tracks"
+ * -"Save Project"
+ * -"Import"
+ * 	+"TGMM tracks"
+ * 	+"Simi BioCell tracks"
  * </pre>
- * 
+ *
  * Comparisons of common words are case insensitive.
- * 
+ *
  * @author Jean-Yves Tinevez
  */
 public class GroupStrings
@@ -67,44 +67,45 @@ public class GroupStrings
 		final List< Group > split = new ArrayList<>();
 		for ( final Group sg : fused )
 			split.addAll( sg.split() );
-		
+
 		return split;
 	}
 
 	private static List< Group > fuseCollection( final Collection< Group > c )
 	{
+		if ( c.size() <= 1 )
+			return new ArrayList<>( c );
+
 		final Deque< Group > champions = new ArrayDeque<>( c );
 		final List< Group > fused = new ArrayList<>();
-		if ( champions.size() > 1 )
+		while ( !champions.isEmpty() )
 		{
-			while ( !champions.isEmpty() )
+
+			// First champion.
+			Group champion = champions.pop();
+
+			// Match the champion against all other challengers.
+			final Set< Group > challengers = new HashSet<>( champions );
+			challengers.remove( champion );
+
+			for ( final Group challenger : challengers )
 			{
-
-				// First champion.
-				Group champion = champions.pop();
-
-				// Match the champion against all other challengers.
-				final Set< Group > challengers = new HashSet<>( champions );
-				challengers.remove( champion );
-
-				for ( final Group challenger : challengers )
+				final Group fusion = champion.fuse( challenger );
+				if ( null == fusion )
 				{
-					final Group fusion = champion.fuse( challenger );
-					if ( null == fusion )
-					{
-						// No fusion possible.
-					}
-					else
-					{
-						// Fusion is possible. The challenger won't become a champion.
-						champions.remove( challenger );
-						// The fusion becomes the champion.
-						champion = fusion;
-					}
+					// No fusion possible.
 				}
-
-				fused.add( champion );
+				else
+				{
+					// Fusion is possible. The challenger won't become a
+					// champion.
+					champions.remove( challenger );
+					// The fusion becomes the champion.
+					champion = fusion;
+				}
 			}
+
+			fused.add( champion );
 		}
 		return fused;
 	}
@@ -139,9 +140,9 @@ public class GroupStrings
 		}
 
 		/**
-		 * Tries to split a single group into several ones when by trying to increase
-		 * the number of common words in the split groups.
-		 * 
+		 * Tries to split a single group into several ones when by trying to
+		 * increase the number of common words in the split groups.
+		 *
 		 * @return a collection of groups.
 		 */
 		private Collection< Group > split()
@@ -153,9 +154,10 @@ public class GroupStrings
 			final List< Group > singletons = new ArrayList<>();
 			for ( final String string : strings )
 			{
-				final Group singleton = new Group( );
+				final Group singleton = new Group();
 				singleton.strings.add( string );
-				// But we remove the common words of this group to check if we can regroup them.
+				// But we remove the common words of this group to check if we
+				// can regroup them.
 				final String[] tokens = string.split( "\\s+" );
 				for ( int i = this.words.size(); i < tokens.length; i++ )
 					singleton.words.add( tokens[ i ] );
@@ -176,14 +178,15 @@ public class GroupStrings
 		}
 
 		/**
-		 * Fuses this subgroup with the specified one. Fusion is made by checking
-		 * whether the first words of the string composition are common. Returns
-		 * <code>null</code> if the two subgroups have no words in common amd fusion is
-		 * impossible.
-		 * 
+		 * Fuses this subgroup with the specified one. Fusion is made by
+		 * checking whether the first words of the string composition are
+		 * common. Returns <code>null</code> if the two subgroups have no words
+		 * in common amd fusion is impossible.
+		 *
 		 * @param other
-		 *                  the subgroup to fuse with.
-		 * @return a fused subgroup, or <code>null</code> if fusion is impossible.
+		 *            the subgroup to fuse with.
+		 * @return a fused subgroup, or <code>null</code> if fusion is
+		 *         impossible.
 		 */
 		private Group fuse( final Group other )
 		{
@@ -212,15 +215,14 @@ public class GroupStrings
 		}
 
 		/**
-		 * Returns the part of the specified string left after the common words in this
-		 * group has been removed.
-		 * 
+		 * Returns the part of the specified string left after the common words
+		 * in this group has been removed.
+		 *
 		 * @param string
-		 *                   the string to determine the suffix of.
+		 *            the string to determine the suffix of.
 		 * @return the suffix.
 		 * @throws IllegalArgumentException
-		 *                                      if the specified string does not belong
-		 *                                      in this group.
+		 *             if the specified string does not belong in this group.
 		 */
 		public String suffix( final String string )
 		{
@@ -246,7 +248,6 @@ public class GroupStrings
 			str.append( "\n - Common words: " + words );
 			return str.toString();
 		}
-
 
 	}
 }

--- a/src/main/java/org/mastodon/revised/util/GroupStrings.java
+++ b/src/main/java/org/mastodon/revised/util/GroupStrings.java
@@ -1,0 +1,252 @@
+package org.mastodon.revised.util;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility class used to group a collection of strings by their common first
+ * words.
+ * <p>
+ * For instance, the 3 strings:
+ * 
+ * <pre>
+ * - "Save Project"
+ * - "Import TGMM tracks"
+ * - "Import Simi BioCell tracks"
+ * </pre>
+ *
+ * will be grouped in 2 groups:
+ * 
+ * <pre>
+ * - "Save Project"
+ * - "Import"
+ * 	+ "TGMM tracks"
+ * 	+ "Simi BioCell tracks"
+ * </pre>
+ * 
+ * Comparisons of common words are case insensitive.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class GroupStrings
+{
+
+	private final List< String > names;
+
+	public GroupStrings()
+	{
+		this.names = new ArrayList<>();
+	}
+
+	public void add( final String string )
+	{
+		names.add( string );
+	}
+
+	public Collection< Group > group()
+	{
+		final List< Group > sgs = new ArrayList<>();
+		for ( final String name : names )
+			sgs.add( new Group( name ) );
+
+		/*
+		 * Fuse.
+		 */
+		final List< Group > fused = fuseCollection( sgs );
+
+		/*
+		 * Split.
+		 */
+		final List< Group > split = new ArrayList<>();
+		for ( final Group sg : fused )
+			split.addAll( sg.split() );
+		
+		return split;
+	}
+
+	private static List< Group > fuseCollection( final Collection< Group > c )
+	{
+		final Deque< Group > champions = new ArrayDeque<>( c );
+		final List< Group > fused = new ArrayList<>();
+		if ( champions.size() > 1 )
+		{
+			while ( !champions.isEmpty() )
+			{
+
+				// First champion.
+				Group champion = champions.pop();
+
+				// Match the champion against all other challengers.
+				final Set< Group > challengers = new HashSet<>( champions );
+				challengers.remove( champion );
+
+				for ( final Group challenger : challengers )
+				{
+					final Group fusion = champion.fuse( challenger );
+					if ( null == fusion )
+					{
+						// No fusion possible.
+					}
+					else
+					{
+						// Fusion is possible. The challenger won't become a champion.
+						champions.remove( challenger );
+						// The fusion becomes the champion.
+						champion = fusion;
+					}
+				}
+
+				fused.add( champion );
+			}
+		}
+		return fused;
+	}
+
+	/**
+	 * Represent a group of strings, grouped by their common first words.
+	 */
+	public static class Group
+	{
+
+		/**
+		 * Collection of strings in this group.
+		 */
+		public final Set< String > strings;
+
+		/**
+		 * Common first words of this group, in order.
+		 */
+		public final List< String > words;
+
+		private Group()
+		{
+			this.words = new ArrayList<>();
+			this.strings = new HashSet<>();
+		}
+
+		private Group( final String string )
+		{
+			this();
+			strings.add( string );
+			words.addAll( Arrays.asList( string.split( "\\s+" ) ) );
+		}
+
+		/**
+		 * Tries to split a single group into several ones when by trying to increase
+		 * the number of common words in the split groups.
+		 * 
+		 * @return a collection of groups.
+		 */
+		private Collection< Group > split()
+		{
+			if ( strings.size() < 3 )
+				return Collections.singleton( this );
+
+			// Recreate each singleton group.
+			final List< Group > singletons = new ArrayList<>();
+			for ( final String string : strings )
+			{
+				final Group singleton = new Group( );
+				singleton.strings.add( string );
+				// But we remove the common words of this group to check if we can regroup them.
+				final String[] tokens = string.split( "\\s+" );
+				for ( int i = this.words.size(); i < tokens.length; i++ )
+					singleton.words.add( tokens[ i ] );
+
+				singletons.add( singleton );
+			}
+			final List< Group > split = fuseCollection( singletons );
+
+			// If it was not interesting to split, don't.
+			if ( split.size() == singletons.size() )
+				return Collections.singleton( this );
+
+			// Now we need to re-add the common words we removed.
+			for ( final Group s : split )
+				s.words.addAll( 0, this.words );
+
+			return split;
+		}
+
+		/**
+		 * Fuses this subgroup with the specified one. Fusion is made by checking
+		 * whether the first words of the string composition are common. Returns
+		 * <code>null</code> if the two subgroups have no words in common amd fusion is
+		 * impossible.
+		 * 
+		 * @param other
+		 *                  the subgroup to fuse with.
+		 * @return a fused subgroup, or <code>null</code> if fusion is impossible.
+		 */
+		private Group fuse( final Group other )
+		{
+			final int nWords = Math.min( this.words.size(), other.words.size() );
+			if ( nWords == 0 )
+				return null;
+
+			int nCommonWords = 0;
+			for ( int i = 0; i < nWords; i++ )
+			{
+				if ( this.words.get( i ).equalsIgnoreCase( other.words.get( i ) ) )
+					nCommonWords = i + 1;
+				else
+					break;
+			}
+			if ( nCommonWords == 0 )
+				return null;
+
+			final Group fused = new Group();
+			fused.strings.addAll( this.strings );
+			fused.strings.addAll( other.strings );
+			for ( int i = 0; i < nCommonWords; i++ )
+				fused.words.add( this.words.get( i ) );
+
+			return fused;
+		}
+
+		/**
+		 * Returns the part of the specified string left after the common words in this
+		 * group has been removed.
+		 * 
+		 * @param string
+		 *                   the string to determine the suffix of.
+		 * @return the suffix.
+		 * @throws IllegalArgumentException
+		 *                                      if the specified string does not belong
+		 *                                      in this group.
+		 */
+		public String suffix( final String string )
+		{
+			if ( !strings.contains( string ) )
+				throw new IllegalArgumentException( "Specified string '" + string + "' does not belong in this group." );
+
+			// Deal with singleton groups.
+			if ( strings.size() == 1 )
+				return string;
+
+			String out = string;
+			for ( final String word : words )
+				out = out.split( word, 2 )[ 1 ];
+
+			return out.trim();
+		}
+
+		@Override
+		public String toString()
+		{
+			final StringBuilder str = new StringBuilder( super.toString() );
+			str.append( "\n - Strings: " + strings );
+			str.append( "\n - Common words: " + words );
+			return str.toString();
+		}
+
+
+	}
+}

--- a/src/main/java/org/mastodon/revised/util/MnemonicsAssigner.java
+++ b/src/main/java/org/mastodon/revised/util/MnemonicsAssigner.java
@@ -16,7 +16,7 @@ import org.mastodon.revised.util.GroupStrings.Group;
  * <p>
  * One instance of this iterator is instantiated per menu. As the menu is built,
  * add the menu item with {@link #add(AbstractButton)} method. When all the menu
- * items have been created and added, call the {@link #assignMnenonics()}
+ * items have been created and added, call the {@link #assignMnemonics()}
  * methods. The mnemonic assigned will be unique for all the menu items, and
  * will be taken from the first letter of the name not already assigned to
  * another mnemonic. If all letters of the name are taken, then no mnemonics are
@@ -39,7 +39,7 @@ public class MnemonicsAssigner
 		buttons.put( button.getText(), button );
 	}
 
-	public void assignMnenonics()
+	public void assignMnemonics()
 	{
 		final GroupStrings grouper = new GroupStrings();
 

--- a/src/main/java/org/mastodon/revised/util/MnemonicsAssigner.java
+++ b/src/main/java/org/mastodon/revised/util/MnemonicsAssigner.java
@@ -1,0 +1,70 @@
+package org.mastodon.revised.util;
+
+import java.awt.event.KeyEvent;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.swing.AbstractButton;
+
+import org.mastodon.revised.util.GroupStrings.Group;
+
+/**
+ * Utility class used to automatically assign sensible mnemonics in JMenus.
+ * <p>
+ * One instance of this iterator is instantiated per menu. As the menu is built,
+ * add the menu item with {@link #add(AbstractButton)} method. When all the menu
+ * items have been created and added, call the {@link #assignMnenonics()}
+ * methods. The mnemonic assigned will be unique for all the menu items, and
+ * will be taken from the first letter of the name not already assigned to
+ * another mnemonic. If all letters of the name are taken, then no mnemonics are
+ * assigned.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class MnemonicsAssigner
+{
+
+	private final Map< String, AbstractButton > buttons;
+
+	public MnemonicsAssigner()
+	{
+		this.buttons = new HashMap< >();
+	}
+
+	public void add( final AbstractButton button )
+	{
+		buttons.put( button.getText(), button );
+	}
+
+	public void assignMnenonics()
+	{
+		final GroupStrings grouper = new GroupStrings();
+
+		for ( final String text : buttons.keySet() )
+			grouper.add( text );
+
+		final Set< Integer > mnemonics = new HashSet<>();
+		final Collection< Group > groups = grouper.group();
+		for ( final Group group : groups )
+		{
+			for ( final String string : group.strings )
+			{
+				final AbstractButton button = buttons.get( string );
+				final String suffix = group.suffix( string );
+				for ( final char c : suffix.toLowerCase().toCharArray() )
+				{
+					final int keyCode = KeyEvent.getExtendedKeyCodeForChar( c );
+					if ( !mnemonics.contains( Integer.valueOf( keyCode ) ) )
+					{
+						mnemonics.add( Integer.valueOf( keyCode ) );
+						button.setMnemonic( keyCode );
+						break;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/test/java/org/mastodon/revised/util/GroupStringsTest.java
+++ b/src/test/java/org/mastodon/revised/util/GroupStringsTest.java
@@ -14,6 +14,18 @@ public class GroupStringsTest
 {
 
 	@Test
+	public void testSingle()
+	{
+		final List< String > names = new ArrayList<>();
+		names.add( "Select to Child" );
+		final GroupStrings gs = new GroupStrings();
+		for ( final String string : names )
+			gs.add( string );
+		final Collection< Group > groups = gs.group();
+		assertEquals( "Did not group into the right numbers of groups.", 1, groups.size() );
+	}
+
+	@Test
 	public void testGroup()
 	{
 		final String s0 = "Import all the TGMM tracks";

--- a/src/test/java/org/mastodon/revised/util/GroupStringsTest.java
+++ b/src/test/java/org/mastodon/revised/util/GroupStringsTest.java
@@ -1,0 +1,102 @@
+package org.mastodon.revised.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.mastodon.revised.util.GroupStrings.Group;
+
+public class GroupStringsTest
+{
+
+	@Test
+	public void testGroup()
+	{
+		final String s0 = "Import all the TGMM tracks";
+		final String s1 = "Import all the Simi BioCell tracks";
+		final String s2 = "Import all the MaMuT project";
+
+		final List< String > names = new ArrayList<>();
+		names.add( s0 );
+		names.add( s1 );
+		names.add( s2 );
+		final GroupStrings gs = new GroupStrings();
+		for ( final String string : names )
+			gs.add( string );
+		final Collection< Group > groups = gs.group();
+		assertEquals( "Did not group into the right numbers of groups.", 1, groups.size() );
+
+		final Group group = groups.iterator().next();
+		final String suffix0 = group.suffix( s0 );
+		assertTrue( "Unexpected suffix.", "TGMM tracks".equals( suffix0 ) );
+	}
+
+	@Test
+	public void testSplit()
+	{
+		final List< String > names = new ArrayList<>();
+		names.add( "Select to Child" );
+		names.add( "Select to Parent" );
+		names.add( "Select to Left" );
+		names.add( "Select to Right" );
+		names.add( "Select Whole Track" );
+		names.add( "Select Track Downward" );
+		names.add( "Select Track Upward" );
+		final GroupStrings gs = new GroupStrings();
+		for ( final String string : names )
+			gs.add( string );
+		final Collection< Group > groups = gs.group();
+		assertEquals( "Did not group into the right numbers of groups.", 3, groups.size() );
+	}
+
+	@Test
+	public void testGlobal()
+	{
+		final List< String > names = new ArrayList<>();
+		names.add( "New Project" );
+		names.add( "Load Project" );
+		names.add( "Save Project" );
+		names.add( "Import TGMM tracks" );
+		names.add( "Import Simi BioCell tracks" );
+		names.add( "Import MaMuT project" );
+		names.add( "Export MaMuT project" );
+		names.add( "New Bdv" );
+		names.add( "New Trackscheme" );
+		names.add( "Preferences..." );
+		names.add( "Settings Toolbar" );
+		names.add( "Undo" );
+		names.add( "Redo" );
+		names.add( "Delete Selection" );
+		names.add( "Select Whole Track" );
+		names.add( "Select Track Downward" );
+		names.add( "Select Track Upward" );
+		names.add( "Load Bdv Settings" );
+		names.add( "Save Bdv Settings" );
+		names.add( "Brightness & Color" );
+		names.add( "Visibility & Grouping" );
+		names.add( "Navigate to Child" );
+		names.add( "Navigate to Parent" );
+		names.add( "Navigate to Left" );
+		names.add( "Navigate to Right" );
+		names.add( "Select to Child" );
+		names.add( "Select to Parent" );
+		names.add( "Select to Left" );
+		names.add( "Select to Right" );
+		names.add( "Toggle Focused Vertex Selection" );
+		names.add( "Edit Vertex Label" );
+
+		final GroupStrings gs = new GroupStrings();
+		for ( final String string : names )
+			gs.add( string );
+
+		final Collection< Group > groups = gs.group();
+//		for ( final Group group : groups )
+//			System.out.println( group ); // DEBUG
+
+		assertEquals( "Did not group into the right numbers of groups.", 18, groups.size() );
+	}
+}


### PR DESCRIPTION
The edit menu now has a submenu named `tags` that allow for settings the tags of the current selection. 

Also, the `EditTagActions` can now harness a number of tagsets and tags larger than 9. Just compose the number you want to select by pressing the key in quick succession. 

If there are less than 9 tags or tagesets, the previous, classical, immediate key listener is used.