### PR TITLE
Fix TrackScheme panel bounds.

### DIFF
--- a/src/main/java/org/mastodon/revised/trackscheme/display/InertialScreenTransformEventHandler.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/InertialScreenTransformEventHandler.java
@@ -3,9 +3,6 @@ package org.mastodon.revised.trackscheme.display;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import net.imglib2.ui.TransformEventHandler;
-import net.imglib2.ui.TransformListener;
-
 import org.mastodon.revised.mamut.KeyConfigContexts;
 import org.mastodon.revised.trackscheme.LineageTreeLayout;
 import org.mastodon.revised.trackscheme.LineageTreeLayout.LayoutListener;
@@ -21,6 +18,9 @@ import org.scijava.ui.behaviour.DragBehaviour;
 import org.scijava.ui.behaviour.ScrollBehaviour;
 import org.scijava.ui.behaviour.util.AbstractNamedBehaviour;
 import org.scijava.ui.behaviour.util.Behaviours;
+
+import net.imglib2.ui.TransformEventHandler;
+import net.imglib2.ui.TransformListener;
 
 public class InertialScreenTransformEventHandler
 	implements
@@ -108,8 +108,8 @@ public class InertialScreenTransformEventHandler
 	private static final double borderRatioY = 0;
 	private static final double maxSizeFactorX = 1;
 	private static final double maxSizeFactorY = 1;
-	private static final double boundXLayoutBorder = 1;
-	private static final double boundYLayoutBorder = 1;
+	static final double boundXLayoutBorder = 0.5;
+	static final double boundYLayoutBorder = 0.5;
 
 	// ...still something else...
 //	private static final double borderRatioX = 0.1;

--- a/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemePanel.java
+++ b/src/main/java/org/mastodon/revised/trackscheme/display/TrackSchemePanel.java
@@ -1,5 +1,8 @@
 package org.mastodon.revised.trackscheme.display;
 
+import static org.mastodon.revised.trackscheme.display.InertialScreenTransformEventHandler.boundXLayoutBorder;
+import static org.mastodon.revised.trackscheme.display.InertialScreenTransformEventHandler.boundYLayoutBorder;
+
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -401,13 +404,13 @@ public class TrackSchemePanel extends JPanel implements
 			xScrollScale = 10000.0 / ( layoutMaxX - layoutMinX + 2 );
 			final int xval = ( int ) ( xScrollScale * t.getMinX() );
 			final int xext = ( int ) ( xScrollScale * ( t.getMaxX() - t.getMinX() ) );
-			final int xmin = ( int ) ( xScrollScale * ( layoutMinX - 1 ) );
-			final int xmax = ( int ) ( xScrollScale * ( layoutMaxX + 1 ) );
+			final int xmin = ( int ) ( xScrollScale * ( layoutMinX - boundXLayoutBorder ) );
+			final int xmax = ( int ) ( xScrollScale * ( layoutMaxX + boundXLayoutBorder ) );
 			yScrollScale = 10000.0 / ( layoutMaxY - layoutMinY + 2 );
 			final int yval = ( int ) ( yScrollScale * t.getMinY() );
 			final int yext = ( int ) ( yScrollScale * ( t.getMaxY() - t.getMinY() ) );
-			final int ymin = ( int ) ( yScrollScale * ( layoutMinY - 1 ) );
-			final int ymax = ( int ) ( yScrollScale * ( layoutMaxY + 1 ) );
+			final int ymin = ( int ) ( yScrollScale * ( layoutMinY - boundYLayoutBorder ) );
+			final int ymax = ( int ) ( yScrollScale * ( layoutMaxY + boundYLayoutBorder ) );
 			ignoreScrollBarChanges = true;
 			xScrollBar.setValues( xval, xext, xmin, xmax );
 			yScrollBar.setValues( yval, yext, ymin, ymax );


### PR DESCRIPTION
Before this commit, some of the TrackScheme panel space was taken by superfluous ranges. For instance, the top-left corner of the panel could go up to the time-point -0.5 and to X=-0.5.
The same for the bottom-left (stop half a time-point after the last time-point) and the other corners.
![](https://files.gitter.im/tpietzsch/OP1f/image.png)

This PR fixes this problem, both in the screen transform handler and with the JScrollBar bounds.
Fixes #92